### PR TITLE
visit temporal-ui through nginx reverse proxy

### DIFF
--- a/docker-compose/README.md
+++ b/docker-compose/README.md
@@ -74,6 +74,7 @@ This script enables the one-click deployment of an all-in-one CSGHub instance, i
 3. The space and registry related configurations in .env can be ignored without Kubernetes cluster. The configuration for integration with the existing Kubernetes cluster can be found in following [section](#Configure-kubernetes).
 4. Run the `startup.sh` script. Once all services are started, you can visit the self-deployed CSGHub service at `http://[SERVER_DOMAIN]`. If SERVER_PORT not 80 default, please visit by adding `:[SERVER_PORT]`.
 5. Once CSGHub instance startup, you can login with default admin account with `root/Root@1234`.
+6. You can access backend async task panel with `/temporal-ui` and default admin account is `admin/Admin@1234` 
 
 ### Notes
 

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./nginx/logs:/var/log/nginx
       - ./nginx/tmpdata:/var/nginx/client_body_temp
+      - ./nginx/htpasswd:/etc/nginx/.htpasswd
     privileged: true
     networks:
       opencsg:
@@ -512,7 +513,7 @@ services:
     depends_on:
       - postgres
     environment:
-      DB: temporal
+      DB: postgres12
       DB_PORT: 5432
       POSTGRES_USER: postgres
       POSTGRES_PWD: sdfa23Sh!322
@@ -531,6 +532,7 @@ services:
     environment:
       TEMPORAL_ADDRESS: temporal:7233
       TEMPORAL_CORS_ORIGINS: http://localhost:3000
+      TEMPORAL_UI_PUBLIC_PATH: /temporal-ui
     ports:
       - "8192:8080"
     restart: always

--- a/docker-compose/nginx/htpasswd
+++ b/docker-compose/nginx/htpasswd
@@ -1,0 +1,1 @@
+admin:$apr1$mwZL.ryZ$z6c2bW.y/ECwkDV1Vbf2j.

--- a/docker-compose/nginx/nginx.conf
+++ b/docker-compose/nginx/nginx.conf
@@ -128,6 +128,18 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        location /temporal-ui/ {
+            auth_basic "Please login with your account:";
+            auth_basic_user_file /etc/nginx/.htpasswd;
+
+            proxy_pass http://temporal-ui:8080;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Host $server_name;
+            proxy_set_header X-Forwarded-Proto $scheme;
+       }
+
         location /endpoint/ {
             proxy_pass http://csghub_server_proxy:8083;
             proxy_set_header Host $host;


### PR DESCRIPTION
1. visit temporal-ui through nginx reverse proxy
1. add basic auth for temproral-ui
1. add docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced documentation for Docker Compose deployment, including access to the asynchronous task panel and updated prerequisites.
	- Added basic authentication for the Nginx server with user credentials.
	- New location for `/temporal-ui/` in Nginx configuration requiring authentication.

- **Configuration Updates**
	- Adjusted database settings for the Temporal service and added a public path for the UI service.
	- Updated Nginx service with new volume mapping for HTTP authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->