### PR TITLE
remove moderation service from compose and create root user trigger first

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -160,9 +160,6 @@ services:
       STARHUB_SERVER_S3_ENABLE_SSL: false
       STARHUB_SERVER_PUBLIC_DOMAIN: http://${SERVER_DOMAIN}:${SERVER_PORT}
       STARHUB_SERVER_MULTI_SYNC_ENABLED: true
-      # model service conenction
-      OPENCSG_MODERATION_SERVER_HOST: http://moderation_server
-      OPENCSG_MODERATION_SERVER_PORT: 8089
       OPENCSG_WORKFLOW_SERVER_ENDPOINT: temporal:7233
     ports:
       - "8080:8080"
@@ -387,9 +384,6 @@ services:
       STARHUB_JWT_SIGNING_KEY: e2kk6awudc3620ed9a
       OPENCSG_USER_SERVER_PORT: 8088
       OPENCSG_USER_SERVER_SIGNIN_SUCCESS_REDIRECT_URL: http://${SERVER_DOMAIN}:${SERVER_PORT}/server/callback
-      # moderation service connection
-      OPENCSG_MODERATION_SERVER_HOST: http://moderation_server
-      OPENCSG_MODERATION_SERVER_PORT: 8089
       # workflow
       OPENCSG_WORKFLOW_SERVER_ENDPOINT: temporal:7233
     ports:
@@ -479,34 +473,6 @@ services:
       opencsg:
         ipv4_address: 192.171.100.230
 
-  moderation_server:
-    image: opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/csghub_server:${CSGHUB_VERSION}
-    entrypoint:
-      - /starhub-bin/starhub
-      - moderation
-      - launch
-    depends_on:
-      - postgres
-      - gitaly
-      - temporal
-    environment:
-      STARHUB_SERVER_API_TOKEN: ${HUB_SERVER_API_TOKEN}
-      STARHUB_DATABASE_DSN: postgresql://postgres:sdfa23Sh!322@postgres:5432/starhub_server?sslmode=disable
-      STARHUB_SERVER_SENSITIVE_CHECK_ENABLE: true
-      STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_ID: ${STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_ID}
-      STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_SECRET: ${STARHUB_SERVER_SENSITIVE_CHECK_ACCESS_KEY_SECRET}
-      STARHUB_SERVER_SENSITIVE_CHECK_REGION: ${STARHUB_SERVER_SENSITIVE_CHECK_REGION}
-      STARHUB_SERVER_GITSERVER_TYPE: gitaly
-      STARHUB_SERVER_GITALY_SERVER_SOCKET: tcp://gitaly:8075
-      STARHUB_SERVER_GITALY_STORGE: default
-      STARHUB_SERVER_GITALY_TOKEN: abc123secret
-      OPENCSG_WORKFLOW_SERVER_ENDPOINT: temporal:7233
-    ports:
-      - "8089:8089"
-    restart: always
-    networks:
-      opencsg:
-        ipv4_address: 192.171.100.229
 
   temporal:
     image: opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/temporalio/auto-setup:1.25.1

--- a/docker-compose/init-scripts/init.sql
+++ b/docker-compose/init-scripts/init.sql
@@ -14,6 +14,33 @@ SET row_security = off;
 SELECT pg_catalog.set_config('search_path', 'public', false);
 
 --
+-- Seed Data for Name: users; Type: TABLE DATA; Schema: public; Owner: postgres
+--
+
+CREATE OR REPLACE FUNCTION promote_root_to_admin()
+    RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.username = 'root' THEN
+        UPDATE public.users
+        SET role_mask = 'admin'
+        WHERE username = 'root';
+
+        -- After update Drop all
+        EXECUTE 'DROP TRIGGER IF EXISTS trigger_promote_root_to_admin ON public.users';
+        EXECUTE 'DROP FUNCTION IF EXISTS promote_root_to_admin()';
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql VOLATILE;
+
+CREATE OR REPLACE TRIGGER trigger_promote_root_to_admin
+    AFTER INSERT ON public.users
+    FOR EACH ROW
+EXECUTE FUNCTION promote_root_to_admin();
+
+
+--
 -- Truncate Data for Name: space_resources; Type: TABLE DATA; Schema: public; Owner: postgres
 --
 
@@ -243,28 +270,3 @@ SELECT pg_catalog.setval(
                true
        );
 
---
--- Seed Data for Name: users; Type: TABLE DATA; Schema: public; Owner: postgres
---
-
-CREATE OR REPLACE FUNCTION promote_root_to_admin()
-    RETURNS TRIGGER AS $$
-BEGIN
-    IF NEW.username = 'root' THEN
-        UPDATE public.users
-        SET role_mask = 'admin'
-        WHERE username = 'root';
-
-        -- After update Drop all
-        EXECUTE 'DROP TRIGGER IF EXISTS trigger_promote_root_to_admin ON public.users';
-        EXECUTE 'DROP FUNCTION IF EXISTS promote_root_to_admin()';
-    END IF;
-
-    RETURN NEW;
-END;
-$$ LANGUAGE plpgsql VOLATILE;
-
-CREATE OR REPLACE TRIGGER trigger_promote_root_to_admin
-    AFTER INSERT ON public.users
-    FOR EACH ROW
-EXECUTE FUNCTION promote_root_to_admin();


### PR DESCRIPTION
1. remove moderation service from compose yml file. it should be ee feature
2. create admin user trigger first in sql init script

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Automated promotion of the 'root' user to 'admin' role upon insertion in the user management system.
  
- **Chores**
	- Removed the `moderation_server` service to streamline architecture.
	- Updated environment variables for existing services to reflect the removal of unused configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->