### PR TITLE
create casdoor config folder before start

### DIFF
--- a/docker/scripts/casdoor-process-wrapper
+++ b/docker/scripts/casdoor-process-wrapper
@@ -21,6 +21,7 @@ check_postgresql
 export POSTGRES_CASDOOR_PASS=${POSTGRES_CASDOOR_PASS:-POSTGRES_CASDOOR_USER}
 export POSTGRES_CASDOOR_DB=${POSTGRES_CASDOOR_DB:-$POSTGRES_CASDOOR_USER}
 
+mkdir -p /etc/casdoor/conf
 if [ -f "/etc/casdoor/app.conf.sample" ] && [ -f "/etc/casdoor/init_data.json.sample" ]; then
   envsubst < /etc/casdoor/app.conf.sample > /etc/casdoor/conf/app.conf
   envsubst < /etc/casdoor/init_data.json.sample > /etc/casdoor/conf/init_data.json


### PR DESCRIPTION
missing to create casdoor config folder: `/etc/casdoor/conf`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a command to create a configuration directory for Casdoor.
	- Introduced default values for environment variables to enhance robustness.
	- Implemented checks for sample configuration files and automated their processing.

- **Bug Fixes**
	- Improved command execution flow for running the Casdoor application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->