### PR TITLE
change temporal health check url

### DIFF
--- a/docker/scripts/temporal-ui-process-wrapper
+++ b/docker/scripts/temporal-ui-process-wrapper
@@ -4,7 +4,7 @@ set -eu -o pipefail
 
 check_temporal() {
   echo "Waiting Temporal ready..."
-  until /usr/bin/curl -s -o /dev/null http://127.0.0.1:7233; do
+  until /usr/bin/curl -s -o /dev/null http://127.0.0.1:7243; do
     sleep 2
   done
   echo "Temporal is ready."


### PR DESCRIPTION
7233 is rpc port, 7243 is http port

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Updated the URL for checking the readiness of the Temporal service, ensuring accurate service monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->