### PR TITLE
remove lfs file from omnibus installer

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -132,6 +132,8 @@ COPY --from=casdoor /web /etc/casdoor/web
 ENV GIN_MODE=release
 COPY --from=server /starhub-bin/starhub /usr/bin/csghub-server
 COPY --from=server /starhub-bin/builder/store/database/seeds /builder/store/database/seeds
+RUN curl -L https://opencsg-public-resource.oss-cn-beijing.aliyuncs.com/csghub/omnibus-demo/tiny-random-Llama-3.tar.gz -o /etc/server/tiny-random-Llama-3.tar.gz
+RUN curl -L https://opencsg-public-resource.oss-cn-beijing.aliyuncs.com/csghub/omnibus-demo/alpaca-gpt4-data-zh.tar.gz -o /etc/server/alpaca-gpt4-data-zh.tar.gz
 
 # ============================================================
 #   Init CSGHub Portal Service

--- a/docker/etc/server/alpaca-gpt4-data-zh.tar.gz
+++ b/docker/etc/server/alpaca-gpt4-data-zh.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:013088f3ea94e7c29efec4ea0e5bf4d776db1139185cf8c9ed3f16aac3792a2a
-size 27723111

--- a/docker/etc/server/tiny-random-Llama-3.tar.gz
+++ b/docker/etc/server/tiny-random-Llama-3.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f8886cea4fd982ebfdc65d6f55b41e526909705474c0fd49bf35b37775883d57
-size 22885791


### PR DESCRIPTION
does not use lfs file in repo for ominbus installer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added functionality to download specific data files during the image build process.
	- Introduced new resources: `tiny-random-Llama-3.tar.gz` and `alpaca-gpt4-data-zh.tar.gz` are now included in the server directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->