### PR TITLE
remove cron job from csghub server

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,9 +14,9 @@ FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/registry:2.8.3 A
 
 FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/csghub_nats:2.10.16 AS nats-server
 
-FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/csghub_server:v1.1.0 AS server
+FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/csghub_server:latest AS server
 
-FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/csghub_portal:v1.1.0 AS portal
+FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/csghub_portal:latest AS portal
 
 FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/casbin/casdoor:v1.733.0 AS casdoor
 

--- a/docker/scripts/csghub-server-process-wrapper
+++ b/docker/scripts/csghub-server-process-wrapper
@@ -108,67 +108,6 @@ if [ "$STARHUB_SERVER_GITSERVER_TYPE" = "gitea" ]; then
   fi
 fi
 
-# Create cron job
-cron=""
-read_and_set_cron() {
-  env_variable=$1
-  default_value=$2
-
-  cron=${!env_variable}
-
-  if [[ -z $cron ]]; then
-    cron=$default_value
-  fi
-}
-
-current_cron_jobs=$(crontab -l 2>/dev/null)
-
-if echo "$current_cron_jobs" | grep -qF "logscan gitea"; then
-  echo "Gitea log scan job already exists"
-else
-  echo "Creating cron job for gitea logscan..."
-  read_and_set_cron "STARHUB_SERVER_CRON_LOGSCAN" "0 23 * * *"
-  (crontab -l ;echo "$cron /usr/bin/bash -c \"source /etc/profile && /usr/bin/csghub-server logscan gitea --path /var/log/csghub-server/gitea.log >> /var/log/csghub-server/cron.log 2>&1\"") | crontab -
-fi
-
-if echo "$current_cron_jobs" | grep -qF "calc-recom-score"; then
-  echo "Calculate score job already exists"
-else
-  echo "Creating cron job for repository recommendation score calculation..."
-  read_and_set_cron "STARHUB_SERVER_CRON_CALC_RECOM_SCORE" "0 1 * * *"
-  (crontab -l ;echo "$cron /usr/bin/bash -c \"source /etc/profile && /usr/bin/csghub-server cron calc-recom-score >> /var/log/csghub-server/cron-calc-recom-score.log 2>&1\"") | crontab -
-fi
-
-if echo "$current_cron_jobs" | grep -qF "create-push-mirror"; then
-    echo "Create push mirror job already exists"
-else
-    echo "Creating cron job for push mirror creation..."
-    read_and_set_cron "STARHUB_SERVER_CRON_PUSH_MIRROR" "*/10 * * * *"
-    (crontab -l ;echo "$cron /usr/bin/bash -c \"source /etc/profile && /usr/bin/csghub-server cron create-push-mirror >> /var/log/csghub-server/create-push-mirror.log 2>&1\"") | crontab -
-fi
-
-if echo "$current_cron_jobs" | grep -qF "check-mirror-progress"; then
-    echo "Check mirror progress job already exists"
-else
-    echo "Creating cron job for update mirror status and progress..."
-    read_and_set_cron "STARHUB_SERVER_CRON_PUSH_MIRROR" "*/5 * * * *"
-    (crontab -l ;echo "$cron /usr/bin/bash -c \"source /etc/profile && /usr/bin/csghub-server mirror check-mirror-progress >> /var/log/csghub-server/check-mirror-progress.log 2>&1\"") | crontab -
-fi
-
-if [ "$STARHUB_SERVER_SAAS" == "false" ]; then
-  if echo "$current_cron_jobs" | grep -qF "sync-as-client"; then
-    echo "Sync as client job already exists"
-  else
-    echo "Creating cron job for sync saas sync verions..."
-    read_and_set_cron "STARHUB_SERVER_CRON_SYNC_AS_CLIENT" "*/10 * * * *"
-    (crontab -l ;echo "$cron /usr/bin/bash -c \"source /etc/profile && /usr/bin/csghub-server sync sync-as-client >> /var/log/csghub-server/cron-sync-as-client.log 2>&1\"") | crontab -
-  fi
-else
-  echo "Saas does not need sync-as-client cron job"
-fi
-# Reload cron server
-service cron restart
-echo "Done."
 
 echo "Database setup..."
 echo "Migration init"


### PR DESCRIPTION
cron job has been removed from csghub_server, and moved to temporal  services.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated base images for the server and portal services to the latest versions.
  
- **Bug Fixes**
	- Removed outdated cron job management from the server process wrapper, streamlining service initialization and readiness checks.

- **Chores**
	- Maintained readiness checks for PostgreSQL, MinIO, and Gitea services, ensuring essential operations are intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->