### PR TITLE
Replace nginx images for docker compose

### DIFF
--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   nginx:
-    image: opencsg-registry.cn-beijing.cr.aliyuncs.com/public/nginx:latest
+    image: opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/nginx:latest
     depends_on:
       - csghub_server
       - csghub_server_proxy
@@ -424,7 +424,7 @@ services:
         ipv4_address: 192.171.100.234
 
   server_proxy_nginx:
-    image: opencsg-registry.cn-beijing.cr.aliyuncs.com/public/nginx:latest
+    image: opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/nginx:latest
     ports:
       - "8090:80"
     volumes:


### PR DESCRIPTION
Replace ngingx image url from `opencsg-registry.cn-beijing.cr.aliyuncs.com/public/nginx:latest` to `opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/nginx:latest`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated image references for `nginx` and `server_proxy_nginx` services to a more specific public namespace within the registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->