### PR TITLE
Replace go-node with golang and fixed checkout without lfs

### DIFF
--- a/.github/workflows/release-compose.yml
+++ b/.github/workflows/release-compose.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          lfs: true
 
       - name: Package Custom Artifact
         id: package_artifact

--- a/.github/workflows/release-docker-image.yml
+++ b/.github/workflows/release-docker-image.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          lfs: true
 
       - name: Cache Prune
         run: |

--- a/.github/workflows/release-helm-chart.yml
+++ b/.github/workflows/release-helm-chart.yml
@@ -16,6 +16,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          lfs: true
 
       - name: Configure Git
         run: |

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -20,7 +20,7 @@ FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/csghub_portal:la
 
 FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/casbin/casdoor:v1.733.0 AS casdoor
 
-FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/go-node AS go-builder
+FROM opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsg_public/golang:latest AS go-builder
 ENV GOPROXY=https://goproxy.cn,direct
 WORKDIR /
 COPY logger .


### PR DESCRIPTION
1. Replace builder image from go-node to golang
2. add lfs checkout attribute to github actions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced workflows for releasing Docker Compose artifacts, Docker images, and Helm charts with support for Git Large File Storage (LFS).
	- Artifacts for Docker Compose and Helm charts are now created and named according to the current Git tag.
	- Release notes are generated based on tag history, improving release management.

- **Bug Fixes**
	- Improved handling of large files during the checkout process in release workflows.

- **Chores**
	- Updated base image in the Dockerfile for building the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->