### PR TITLE
change to use llamafactory 1.20 version

### DIFF
--- a/docker-compose/init-scripts/initialize.sql
+++ b/docker-compose/init-scripts/initialize.sql
@@ -115,7 +115,7 @@ $$;
 INSERT INTO public.runtime_frameworks (id, frame_name, frame_version, frame_image, frame_cpu_image, enabled, container_port, type)
     VALUES
     (1, 'VLLM', '3.1', 'vllm-local:3.1', 'vllm-cpu:2.4', 1, 8000, 1),
-    (2, 'LLaMA-Factory', '1.21', 'llama-factory:1.21-cuda12.1-devel-ubuntu22.04-py310-torch2.1.2', '', 1, 8000, 2),
+    (2, 'LLaMA-Factory', '1.20', 'llama-factory:1.20-cuda12.1-devel-ubuntu22.04-py310-torch2.1.2', '', 1, 8000, 2),
     (3, 'TGI', '3.0', 'tgi:3.0', '', 1, 8000, 1),
     (4, 'NIM-llama3-8b-instruct', 'latest', 'nvcr.io/nim/meta/llama3-8b-instruct:latest', '', 1, 8000, 1),
     (5, 'NIM-llama3-70b-instruct', 'latest', 'nvcr.io/nim/meta/llama3-70b-instruct:latest', '', 1, 8000, 1),

--- a/docker/etc/server/initialize.sql
+++ b/docker/etc/server/initialize.sql
@@ -115,7 +115,7 @@ $$;
 INSERT INTO public.runtime_frameworks (id, frame_name, frame_version, frame_image, frame_cpu_image, enabled, container_port, type)
     VALUES
     (1, 'VLLM', '3.1', 'vllm-local:3.1', 'vllm-cpu:2.4', 1, 8000, 1),
-    (2, 'LLaMA-Factory', '1.21', 'llama-factory:1.21-cuda12.1-devel-ubuntu22.04-py310-torch2.1.2', '', 1, 8000, 2),
+    (2, 'LLaMA-Factory', '1.20', 'llama-factory:1.20-cuda12.1-devel-ubuntu22.04-py310-torch2.1.2', '', 1, 8000, 2),
     (3, 'TGI', '3.0', 'tgi:3.0', '', 1, 8000, 1),
     (4, 'NIM-llama3-8b-instruct', 'latest', 'nvcr.io/nim/meta/llama3-8b-instruct:latest', '', 1, 8000, 1),
     (5, 'NIM-llama3-70b-instruct', 'latest', 'nvcr.io/nim/meta/llama3-70b-instruct:latest', '', 1, 8000, 1),

--- a/helm-chart/charts/csghub/charts/server/initialize.sql
+++ b/helm-chart/charts/csghub/charts/server/initialize.sql
@@ -115,7 +115,7 @@ $$;
 INSERT INTO public.runtime_frameworks (id, frame_name, frame_version, frame_image, frame_cpu_image, enabled, container_port, type)
     VALUES
     (1, 'VLLM', '3.1', 'vllm-local:3.1', 'vllm-cpu:2.4', 1, 8000, 1),
-    (2, 'LLaMA-Factory', '1.21', 'llama-factory:1.21-cuda12.1-devel-ubuntu22.04-py310-torch2.1.2', '', 1, 8000, 2),
+    (2, 'LLaMA-Factory', '1.20', 'llama-factory:1.20-cuda12.1-devel-ubuntu22.04-py310-torch2.1.2', '', 1, 8000, 2),
     (3, 'TGI', '3.0', 'tgi:3.0', '', 1, 8000, 1),
     (4, 'NIM-llama3-8b-instruct', 'latest', 'nvcr.io/nim/meta/llama3-8b-instruct:latest', '', 1, 8000, 1),
     (5, 'NIM-llama3-70b-instruct', 'latest', 'nvcr.io/nim/meta/llama3-70b-instruct:latest', '', 1, 8000, 1),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated version number for 'LLaMA-Factory' from '1.21' to '1.20' in the `runtime_frameworks` table across multiple initialization scripts.
	- Added conditional logic to drop the NOT NULL constraint on the `frame_npu_image` column if the `frame_npu_image_01` column exists.

- **Bug Fixes**
	- Ensured correct handling of database schema and ID sequences during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->