### PR TITLE
Fixed wrong column name

### DIFF
--- a/docker-compose/init-scripts/initialize.sql
+++ b/docker-compose/init-scripts/initialize.sql
@@ -102,7 +102,7 @@ BEGIN
     IF EXISTS (
         SELECT FROM information_schema.columns
         WHERE table_name = 'runtime_frameworks'
-            AND column_name = 'frame_npu_image_01'
+            AND column_name = 'frame_npu_image'
     )
     THEN
         ALTER TABLE IF EXISTS runtime_frameworks

--- a/docker/etc/server/initialize.sql
+++ b/docker/etc/server/initialize.sql
@@ -102,7 +102,7 @@ BEGIN
     IF EXISTS (
         SELECT FROM information_schema.columns
         WHERE table_name = 'runtime_frameworks'
-            AND column_name = 'frame_npu_image_01'
+            AND column_name = 'frame_npu_image'
     )
     THEN
         ALTER TABLE IF EXISTS runtime_frameworks

--- a/helm-chart/charts/csghub/charts/server/initialize.sql
+++ b/helm-chart/charts/csghub/charts/server/initialize.sql
@@ -102,7 +102,7 @@ BEGIN
     IF EXISTS (
         SELECT FROM information_schema.columns
         WHERE table_name = 'runtime_frameworks'
-            AND column_name = 'frame_npu_image_01'
+            AND column_name = 'frame_npu_image'
     )
     THEN
         ALTER TABLE IF EXISTS runtime_frameworks


### PR DESCRIPTION
Refactor column name `frame_npu_image_01` to `frame_npu_image_01`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced data seeding process for `space_resources`, `runtime_frameworks`, and `runtime_architectures` tables.
	- Improved handling of conflicts during data insertion.

- **Bug Fixes**
	- Modified column name from `frame_npu_image_01` to `frame_npu_image` in the `runtime_frameworks` table, including adjustments to constraints. 

- **Chores**
	- Updated sequence values for various ID sequences to ensure they reflect the maximum IDs in their respective tables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->