### PR TITLE
Fixed helm install failed

### DIFF
--- a/helm-chart/charts/csghub/charts/builder/templates/statefulset.yaml
+++ b/helm-chart/charts/csghub/charts/builder/templates/statefulset.yaml
@@ -131,8 +131,6 @@ spec:
           env:
             - name: DOCKER_HOST
               value: "tcp://localhost:2375"
-            - name: DOCKER_DRIVER
-              value: overlay2
             - name: DOCKER_TLS_CERTDIR
               value: ""
           resources:

--- a/helm-chart/charts/csghub/charts/runner/templates/deployment.yaml
+++ b/helm-chart/charts/csghub/charts/runner/templates/deployment.yaml
@@ -72,6 +72,8 @@ spec:
                 name: {{ include "common.names.custom" (list . "server") }}
             - configMapRef:
                 name: {{ include "common.names.custom" (list . "builder") }}
+            - secretRef:
+                name: {{ include "common.names.custom" (list . "nats") }}
             {{- if .Values.global.postgresql.enabled }}
             - secretRef:
                 name: {{ include "common.names.custom" (list . "postgresql") }}


### PR DESCRIPTION
1. Fixed container docker in builder cannot be started because `DOCKER_DRIVER=overlay2`
2. Fixed runner missing references nats secrets