### PR TITLE
[Helm] Fix runner namespace templates not separated issue

### DIFF
--- a/helm/charts/csghub/charts/runner/templates/namespace.yaml
+++ b/helm/charts/csghub/charts/runner/templates/namespace.yaml
@@ -13,6 +13,7 @@ metadata:
     helm.sh/resource-policy: keep
     {{ include "common.labels" . | nindent 4 }}
 {{- if not .Values.global.deploy.mergingNamespace }}
+---
 apiVersion: v1
 kind: Namespace
 metadata:


### PR DESCRIPTION
The namespace.yaml of the running missing a '---' to separate the two `Namespace` configurations which could lead to error if the two configurations are enabled together.