### PR TITLE
feat(csghub): add mirror sync repo size limits

### DIFF
--- a/charts/csghub/templates/csghub/configmap.yaml
+++ b/charts/csghub/templates/csghub/configmap.yaml
@@ -169,6 +169,10 @@ data:
   STARHUB_SERVER_ENABLE_HTTPS: {{ dig "tls" "enabled" "false" $IngressConfig | quote }}
   STARHUB_SERVER_MIRRORSERVER_ENABLE: "false"
   STARHUB_SERVER_MIRROR_REMOTE: "false"
+  {{- if $serverSvc.mirrorSync }}
+  STARHUB_SERVER_MIRROR_MAX_MODEL_REPO_SIZE: {{ $serverSvc.mirrorSync.maxModelRepoSize | quote }}
+  STARHUB_SERVER_MIRROR_MAX_DATASET_REPO_SIZE: {{ $serverSvc.mirrorSync.maxDatasetRepoSize | quote }}
+  {{- end }}
   STARHUB_SERVER_API_TOKEN: {{ $apiToken | quote }}
   {{- $jwtToken := dig "STARHUB_JWT_SIGNING_KEY" (randNumeric 8 | sha1sum) $data }}
   STARHUB_JWT_SIGNING_KEY: {{ $jwtToken | quote }}

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -208,6 +208,11 @@ server:
     enabled: true                          # Enable or disable multi-sync service
     proxy: ""                              # Proxy for model synchronization
 
+  ## Mirror sync configuration
+  mirrorSync:
+    maxModelRepoSize: "536870912000"       # Max model repo size for mirror sync in bytes (default 500GB)
+    maxDatasetRepoSize: "536870912000"     # Max dataset repo size for mirror sync in bytes (default 500GB)
+
   ## API documentation
   swaggerAPI:
     enabled: false                         # Enable Swagger API assistants


### PR DESCRIPTION
Add STARHUB_SERVER_MIRROR_MAX_MODEL_REPO_SIZE and STARHUB_SERVER_MIRROR_MAX_DATASET_REPO_SIZE env vars to limit the size of mirrored model/dataset repositories. Defaults to 200Gi.