### PR TITLE
fix(xnet): override entrypoint to skip config.toml

### DIFF
--- a/charts/csghub/templates/xnet/deployment.yaml
+++ b/charts/csghub/templates/xnet/deployment.yaml
@@ -66,6 +66,10 @@ spec:
         - name: {{ $service.name }}
           image: {{ include "common.image" (list . $service.image) }}
           imagePullPolicy: {{ or $service.image.pullPolicy .Values.global.image.pullPolicy }}
+          command:
+            - "/xnet-bin/xnet"
+            - "start"
+            - "server"
           ports:
             - containerPort: 8097
               name: {{ dig "service" "name" $service.name $service }}


### PR DESCRIPTION
Remove reference to config.toml in xnet image entrypoint by directly executing /xnet-bin/xnet with command override. Configuration is now provided entirely via ConfigMap env vars.