### PR TITLE
feat(runner): add STARHUB_SERVER_SPACE_BUILD_TIMEOUT_IN_MINUTES

### DIFF
--- a/charts/runner/templates/configmap.yaml
+++ b/charts/runner/templates/configmap.yaml
@@ -88,6 +88,7 @@ data:
   {{- $capacityLabel := $service.gpuModelLabel.capacityLabel }}
   STARHUB_SERVER_GPU_MODEL_LABEL: '[{"type_label": {{ $typeLabel | quote }}, "capacity_label": {{ $capacityLabel | quote }}}]'
   STARHUB_SERVER_MODEL_DEPLOY_TIMEOUT_IN_MINUTES: {{ $service.model.deployTimeout | default 60 | quote }}
+  STARHUB_SERVER_SPACE_BUILD_TIMEOUT_IN_MINUTES: {{ $service.model.buildTimeout | default 30 | quote }}
   {{- if $isBuiltIn }}
   STARHUB_SERVER_MODEL_DOWNLOAD_ENDPOINT: {{ include "common.endpoint.csghub" . | quote }}
   {{- else }}

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -123,6 +123,7 @@ pipIndexUrl: "https://pypi.tuna.tsinghua.edu.cn/simple/"  # Custom pip repositor
 extraBuildArgs: []                     # Extra Kaniko build arguments
 model:                                 # Model image configuration
   deployTimeout: "60"                  # Timeout (in seconds) for model deployment operations
+  buildTimeout: 30                     # Timeout (in minutes) for space build operations
   registry: ""                         # Custom image registry for model-related images (empty uses global registry)
 
 ## GPU resource configuration


### PR DESCRIPTION
Add space build timeout configuration support.

## Changes
- charts/runner/values.yaml: Add model.buildTimeout: 30 (default 30 min)
- charts/runner/templates/configmap.yaml: Inject STARHUB_SERVER_SPACE_BUILD_TIMEOUT_IN_MINUTES env var