### PR TITLE
feat(csghub): add STARHUB_SERVER_SPACE_BUILD_TIMEOUT_IN_MINUTES

### DIFF
--- a/charts/csghub/templates/csghub/configmap.yaml
+++ b/charts/csghub/templates/csghub/configmap.yaml
@@ -184,6 +184,7 @@ data:
   ## Server Configuration for Model
   {{- $registry := or $runnerSvc.model.registry .Values.global.image.registry "docker.io" }}
   STARHUB_SERVER_MODEL_DOCKER_REG_BASE: {{ $registry | quote }}
+  STARHUB_SERVER_SPACE_BUILD_TIMEOUT_IN_MINUTES: {{ $serverSvc.space.buildTimeout | default 30 | quote }}
 
   ## Server Configuration for Multiple-Sync
   STARHUB_SERVER_MULTI_SYNC_ENABLED: {{ $serverSvc.multiSync.enabled | quote }}

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -213,6 +213,10 @@ server:
     maxModelRepoSize: "536870912000"       # Max model repo size for mirror sync in bytes (default 500GB)
     maxDatasetRepoSize: "536870912000"     # Max dataset repo size for mirror sync in bytes (default 500GB)
 
+  ## Space build configuration
+  space:
+    buildTimeout: "30"                    # Timeout (in minutes) for space build operations
+
   ## API documentation
   swaggerAPI:
     enabled: false                         # Enable Swagger API assistants

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -273,7 +273,7 @@ reloader:
 
 ## Prometheus monitoring configuration
 prometheus:
-  enabled: true                            # Enable Prometheus
+  enabled: false                          # Enable Prometheus
 
   gateway:
     enabled: false                         # Enable gateway for Prometheus


### PR DESCRIPTION
Add space build timeout configuration for temporal worker.

## Changes
- charts/csghub/values.yaml: Add server.space.buildTimeout (default: 30 min)
- charts/csghub/templates/csghub/configmap.yaml: Inject STARHUB_SERVER_SPACE_BUILD_TIMEOUT_IN_MINUTES env var