### PR TITLE
fix(quick-install): set runner.storageClassName default to nfs-client

### DIFF
--- a/scripts/quick_install.sh
+++ b/scripts/quick_install.sh
@@ -796,8 +796,10 @@ if [[ -z "$K3S_SERVER" ]]; then
   if [[ "$ENABLE_NFS_PV" == "true" ]]; then
     HELM_EXTRA_ARGS+=(--set dataflow.dataflow.persistence.storageClass='nfs-client')
     HELM_EXTRA_ARGS+=(--set csgship.web.persistence.storageClass='nfs-client')
+    HELM_EXTRA_ARGS+=(--set runner.storageClassName='nfs-client')
   else
     HELM_EXTRA_ARGS+=(--set dataflow.dataflow.persistence.accessModes[0]="ReadWriteOnce")
+    HELM_EXTRA_ARGS+=(--set runner.storageClassName='local-path')
   fi
 
   HELM_EXTRA_ARGS+=(--set global.edition='ee')


### PR DESCRIPTION
Set runner.storageClassName default value in quick_install.sh:
- NFS enabled (default): `nfs-client`
- NFS disabled: `local-path`

This ensures runner PVCs use the correct storage class based on deployment mode.