### PR TITLE
fix(agentichub): add --no-sync flag to csgbot uv run command

### DIFF
--- a/charts/agentichub/templates/csgbot/deployment.yaml
+++ b/charts/agentichub/templates/csgbot/deployment.yaml
@@ -65,7 +65,7 @@ spec:
           command:
             - "/bin/bash"
             - "-c"
-            - "uv run uvicorn csgbot.server:app --host 0.0.0.0 --port 8070 --workers 1 --no-access-log"
+            - "uv run --no-sync uvicorn csgbot.server:app --host 0.0.0.0 --port 8070 --workers 1 --no-access-log"
           ports:
             - containerPort: 8070
               name: {{ dig "service" "name" $service.name $service }}


### PR DESCRIPTION
## Summary
- Add `--no-sync` flag to the `uv run` command in CSGBot deployment
- This prevents uv from attempting to sync the virtual environment in the container, which can cause issues when the deployment already has the environment set up

## Test plan
- [ ] Deploy agentichub chart to a test environment
- [ ] Verify CSGBot pod starts successfully with the new `uv run --no-sync` command
- [ ] Confirm CSGBot is responding on port 8070

🤖 Generated with [Claude Code](https://claude.com/claude-code)