### PR TITLE
fix(runner): rename scaleToZeroGracePeriod to scaleToZeroPodRetentionPeriod

### DIFF
--- a/charts/runner/templates/knativeserving.yaml
+++ b/charts/runner/templates/knativeserving.yaml
@@ -76,7 +76,7 @@ spec:
       {{ $service.knative.serving.domain }}: ""
     autoscaler:
       enable-scale-to-zero: {{ $service.knative.serving.autoscaler.enableScaleToZero | quote }}
-      scale-to-zero-grace-period: {{ $service.knative.serving.autoscaler.scaleToZeroGracePeriod | quote }}
+      scale-to-zero-pod-retention-period: {{ $service.knative.serving.autoscaler.scaleToZeroPodRetentionPeriod | quote }}
     network:
       ingress-class: kourier.ingress.networking.knative.dev
     features:

--- a/charts/runner/tests/configmap_test.yaml
+++ b/charts/runner/tests/configmap_test.yaml
@@ -99,7 +99,7 @@ set:
 
       autoscaler:
         enableScaleToZero: true
-        scaleToZeroGracePeriod: 30m
+        scaleToZeroPodRetentionPeriod: 30m
 
   rbac:
     create: true

--- a/charts/runner/tests/knativeserving_test.yaml
+++ b/charts/runner/tests/knativeserving_test.yaml
@@ -82,7 +82,7 @@ set:
       domain: unittest.io
       autoscaler:
         enableScaleToZero: true
-        scaleToZeroGracePeriod: 30m
+        scaleToZeroPodRetentionPeriod: 30m
 
   rbac:
     create: true
@@ -187,7 +187,7 @@ tests:
           path: spec.config.autoscaler.enable-scale-to-zero
           value: "true"
       - equal:
-          path: spec.config.autoscaler.scale-to-zero-grace-period
+          path: spec.config.autoscaler.scale-to-zero-pod-retention-period
           value: 30m
       - equal:
           path: spec.config.network.ingress-class
@@ -275,9 +275,9 @@ tests:
       knative:
         serving:
           autoscaler:
-            scaleToZeroGracePeriod: 60s
+            scaleToZeroPodRetentionPeriod: 60s
     documentIndex: 1
     asserts:
       - equal:
-          path: spec.config.autoscaler.scale-to-zero-grace-period
+          path: spec.config.autoscaler.scale-to-zero-pod-retention-period
           value: 60s

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -150,7 +150,7 @@ knative:
     ## Enable ksvc scale pod to 0 (stop space/inference/finetune/... instance)
     autoscaler:
       enableScaleToZero: true
-      scaleToZeroGracePeriod: "60m"
+      scaleToZeroPodRetentionPeriod: "60m"
 
     ## Deprecated configuration (for backward compatibility)
     services: []


### PR DESCRIPTION
Knative deprecated `scale-to-zero-grace-period` in favor of `scale-to-zero-pod-retention-period`. This aligns the runner chart with the new key.

## Changes
- `charts/runner/values.yaml`: `scaleToZeroGracePeriod` → `scaleToZeroPodRetentionPeriod`
- `charts/runner/templates/knativeserving.yaml`: KnativeServing config key + values reference
- `charts/runner/tests/knativeserving_test.yaml`: 4 references (2 input sets + 2 asserts)
- `charts/runner/tests/configmap_test.yaml`: 1 input set

## Verification
```
helm unittest charts/runner -f tests/*_test.yaml
# Charts: 1 passed, 1 total
# Test Suites: 6 passed, 6 total  
# Tests: 22 passed, 22 total
```

## Out of scope
`deploy/knative/serving-core.yaml` is Knative upstream release manifest (Apache 2.0). It still references the deprecated key but should be re-synced from upstream, not hand-edited.