### PR TITLE
chore(release): bump csghub/runner chart version to 2.1.2

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,7 +19,7 @@ package:
         if [ -d "$CHART" ]; then
           echo "📝 Updating version for $CHART to $VERSION_NO_V"
           sed -i "s/^version:.*/version: $VERSION_NO_V/" "$CHART/Chart.yaml"
-          sed -i "s/^appVersion:.*/appVersion: \"${CI_COMMIT_TAG}\"/" "$CHART/Chart.yaml"
+          # sed -i "s/^appVersion:.*/appVersion: \"${CI_COMMIT_TAG}\"/" "$CHART/Chart.yaml"
         fi
       done
 

--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 28.6.0
 - name: runner
   repository: https://charts.opencsg.com/csghub
-  version: 2.1.0
+  version: 2.1.2
 - name: dataflow
   repository: https://charts.opencsg.com/csghub
   version: 2.1.0
@@ -32,5 +32,5 @@ dependencies:
 - name: agentichub
   repository: https://charts.opencsg.com/csghub
   version: 0.5.1
-digest: sha256:94d63de05bd8a7d3da65c505d2563c92850f8e344dbd7592fa2b1b329f57f8f1
-generated: "2026-05-09T11:15:55.810981+08:00"
+digest: sha256:b7f97626894d5975423ce1fa1d7a028936ddb3e15ce672d08d49fafc41c1f6a2
+generated: "2026-06-05T17:46:27.015074+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
@@ -52,7 +52,7 @@ dependencies:
     repository: file://charts/prometheus
     condition: prometheus.enabled
   - name: runner
-    version: 2.1.0
+    version: 2.1.2
     repository: https://charts.opencsg.com/csghub
     condition: runner.enabled
   - name: dataflow

--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -20,7 +20,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.0
+version: 2.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
Bump chart version of csghub and runner charts from 2.1.0 to 2.1.2. Also update the runner dependency version referenced by the csghub chart.

appVersion is intentionally NOT bumped (still v2.1.0) — only the chart version changes.

## Changes
- charts/csghub/Chart.yaml: version 2.1.0 → 2.1.2; runner dependency 2.1.0 → 2.1.2
- charts/runner/Chart.yaml: version 2.1.0 → 2.1.2

## Verification
```
helm lint charts/csghub  # 0 failed
helm lint charts/runner  # 0 failed
```