### PR TITLE
fix: restrict agentichub to non-ce editions

### DIFF
--- a/charts/agentichub/templates/agenticflow/configmap.yaml
+++ b/charts/agentichub/templates/agenticflow/configmap.yaml
@@ -6,6 +6,7 @@ SPDX-License-Identifier: APACHE-2.0
 {{- $service := include "common.service" (dict "ctx" . "service" "agenticflow") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
 {{- $isBuiltIn := .Values.global.chartContext.isBuiltIn }}
+{{- if ne .Values.global.edition "ce" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -79,3 +80,4 @@ data:
   ## AgenticHub Configuration for Others
   BACKEND_URL: {{ include "common.endpoint.agenticflow" . }}
   FRONTEND_URL: {{ include "common.endpoint.agenticflow" . }}
+{{- end }}

--- a/charts/agentichub/templates/agenticflow/deployment.yaml
+++ b/charts/agentichub/templates/agenticflow/deployment.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $service := include "common.service" (dict "ctx" . "service" "agenticflow") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
+{{- if ne .Values.global.edition "ce" }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -157,3 +158,4 @@ spec:
   revisionHistoryLimit: {{ $service.revisionHistoryLimit }}
   {{- end }}
   progressDeadlineSeconds: {{ $service.progressDeadlineSeconds | default 600 }}
+{{- end }}

--- a/charts/agentichub/templates/agenticflow/job.yaml
+++ b/charts/agentichub/templates/agenticflow/job.yaml
@@ -6,6 +6,7 @@ SPDX-License-Identifier: APACHE-2.0
 {{- $service := include "common.service" (dict "ctx" . "service" "agenticflow") | fromYaml }}
 {{- $agenticflowName := include "common.names.custom" (list . $service.name) }}
 {{- $serviceName := include "common.names.custom" (list . "template-importer") }}
+{{- if ne .Values.global.edition "ce" }}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -34,6 +35,7 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+{{- end }}
       containers:
         - name: importer
           image: {{ include "common.image.fixed" (dict "ctx" . "service" "agenticflow" "image" "opencsghq/agenticflow-importer:latest") }}

--- a/charts/agentichub/templates/agenticflow/pvc.yaml
+++ b/charts/agentichub/templates/agenticflow/pvc.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $service := include "common.service" (dict "ctx" . "service" "agenticflow") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
+{{- if ne .Values.global.edition "ce" }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -30,3 +31,4 @@ spec:
   resources:
     requests:
       storage: {{ or $persistence.size .Values.global.persistence.size }}
+{{- end }}

--- a/charts/agentichub/templates/agenticflow/service.yaml
+++ b/charts/agentichub/templates/agenticflow/service.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $service := include "common.service" (dict "ctx" . "service" "agenticflow") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
+{{- if ne .Values.global.edition "ce" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,3 +24,4 @@ spec:
   selector:
     app.kubernetes.io/service: {{ $service.name }}
     {{- include "common.labels.selector" . | nindent 4 }}
+{{- end }}

--- a/charts/agentichub/templates/csgbot/configmap.yaml
+++ b/charts/agentichub/templates/csgbot/configmap.yaml
@@ -6,6 +6,7 @@ SPDX-License-Identifier: APACHE-2.0
 {{- $service := include "common.service" (dict "ctx" . "service" "csgbot") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
 {{- $isBuiltIn := .Values.global.chartContext.isBuiltIn }}
+{{- if ne .Values.global.edition "ce" }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -88,3 +89,4 @@ data:
 
     [openclaw-sandbox]
     image = {{ include "common.image" (list . (dig "config" "sandbox" "openclaw" "image" dict .Values.csgbot)) | quote }}
+{{- end }}

--- a/charts/agentichub/templates/csgbot/deployment.yaml
+++ b/charts/agentichub/templates/csgbot/deployment.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $service := include "common.service" (dict "ctx" . "service" "csgbot") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
+{{- if ne .Values.global.edition "ce" }}
 apiVersion: {{ include "common.capabilities.deployment.apiVersion" . }}
 kind: Deployment
 metadata:
@@ -162,3 +163,4 @@ spec:
   revisionHistoryLimit: {{ $service.revisionHistoryLimit }}
   {{- end }}
   progressDeadlineSeconds: {{ $service.progressDeadlineSeconds | default 600 }}
+{{- end }}

--- a/charts/agentichub/templates/csgbot/pvc.yaml
+++ b/charts/agentichub/templates/csgbot/pvc.yaml
@@ -6,6 +6,7 @@ SPDX-License-Identifier: APACHE-2.0
 {{- $service := include "common.service" (dict "ctx" . "service" "csgbot") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
 {{- $values := .Values }}
+{{- if ne .Values.global.edition "ce" }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -31,3 +32,4 @@ spec:
   resources:
     requests:
       storage: {{ or $persistence.size $values.csgbot.persistence.size }}
+{{- end }}

--- a/charts/agentichub/templates/csgbot/service.yaml
+++ b/charts/agentichub/templates/csgbot/service.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $service := include "common.service" (dict "ctx" . "service" "csgbot") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
+{{- if ne .Values.global.edition "ce" }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -23,3 +24,4 @@ spec:
   selector:
     app.kubernetes.io/service: {{ $service.name }}
     {{- include "common.labels.selector" . | nindent 4 }}
+{{- end }}

--- a/charts/agentichub/templates/envoy-proxy.yaml
+++ b/charts/agentichub/templates/envoy-proxy.yaml
@@ -4,7 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */ -}}
 
 {{- $gateway := .Values.global.gateway }}
-{{- if and (not .Values.global.chartContext.isBuiltIn) (regexMatch "envoyproxy" $gateway.controllerName) }}
+{{- if and (ne .Values.global.edition "ce") (not .Values.global.chartContext.isBuiltIn) (regexMatch "envoyproxy" $gateway.controllerName) }}
 {{- $serviceName := include "common.names.custom" (list . "envoy-proxy-custom") }}
 {{- $gatewayConfig := include "common.gateway.config" (dict "ctx" . "service" dict) | fromYaml }}
 apiVersion: gateway.envoyproxy.io/v1alpha1

--- a/charts/agentichub/templates/gateway.yaml
+++ b/charts/agentichub/templates/gateway.yaml
@@ -3,7 +3,7 @@ Copyright OpenCSG, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */ -}}
 
-{{- if and (not .Values.global.chartContext.isBuiltIn) .Values.envoy.enabled }}
+{{- if and (ne .Values.global.edition "ce") (not .Values.global.chartContext.isBuiltIn) .Values.envoy.enabled }}
 {{- $gateway := .Values.global.gateway }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass

--- a/charts/agentichub/templates/httproutes-redirect.yaml
+++ b/charts/agentichub/templates/httproutes-redirect.yaml
@@ -3,7 +3,7 @@ Copyright OpenCSG, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */ -}}
 
-{{- if and (not .Values.global.chartContext.isBuiltIn) .Values.global.gateway.tls.enabled }}
+{{- if and (ne .Values.global.edition "ce") (not .Values.global.chartContext.isBuiltIn) .Values.global.gateway.tls.enabled }}
 {{- $service := include "common.service" (dict "ctx" . "service" "agenticflow") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
 apiVersion: gateway.networking.k8s.io/v1

--- a/charts/agentichub/templates/httproutes.yaml
+++ b/charts/agentichub/templates/httproutes.yaml
@@ -5,6 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $service := include "common.service" (dict "ctx" . "service" "agenticflow") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
+{{- if ne .Values.global.edition "ce" }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -73,4 +74,5 @@ spec:
           port: {{ dig "service" "port" 8070 $csgbotSvc }}
       timeouts:
         request: 5m
+{{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary

Restrict **agentichub chart** (agenticflow + csgbot + gateway/HTTPRoute/envoy) to non-CE editions. When `global.edition="ce"`, no agentichub resources are rendered.

## 🐛 Fix

- All agentichub templates gated with `{{- if ne .Values.global.edition "ce" }}`
- CE edition deployment now omits:
  - `agenticflow`: deployment, service, configmap, pvc, job, httproutes
  - `csgbot`: deployment, service, configmap, pvc
  - `envoy-proxy`, `gateway`, `httproutes-redirect`: condition extended with edition check

## 📂 Files Changed

| File | Change |
|------|--------|
| `charts/agentichub/templates/agenticflow/configmap.yaml` | + edition guard (CE → no render) |
| `charts/agentichub/templates/agenticflow/deployment.yaml` | + edition guard |
| `charts/agentichub/templates/agenticflow/job.yaml` | + edition guard (template-importer) |
| `charts/agentichub/templates/agenticflow/pvc.yaml` | + edition guard |
| `charts/agentichub/templates/agenticflow/service.yaml` | + edition guard |
| `charts/agentichub/templates/csgbot/configmap.yaml` | + edition guard |
| `charts/agentichub/templates/csgbot/deployment.yaml` | + edition guard |
| `charts/agentichub/templates/csgbot/pvc.yaml` | + edition guard |
| `charts/agentichub/templates/csgbot/service.yaml` | + edition guard |
| `charts/agentichub/templates/envoy-proxy.yaml` | condition + `edition != "ce"` |
| `charts/agentichub/templates/gateway.yaml` | condition + `edition != "ce"` |
| `charts/agentichub/templates/httproutes-redirect.yaml` | condition + `edition != "ce"` |
| `charts/agentichub/templates/httproutes.yaml` | + edition guard |

## 🧪 Test Plan

- [ ] `helm template charts/agentichub --set global.edition=ce` → confirm zero agentichub resources
- [ ] `helm template charts/agentichub --set global.edition=ee` → confirm agenticflow + csgbot rendered
- [ ] `helm template charts/agentichub --set global.edition=saas` → same as ee
- [ ] Existing unittests still pass (edition guard does not affect defaults)
