### PR TITLE
chore(release): bump runner chart version to 2.2.0

### DIFF
--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -20,13 +20,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.2
+version: 2.2.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v2.1.0
+appVersion: v2.2.0
 
 # Defined dependencies for subChart
 dependencies:

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -48,7 +48,7 @@ global:
   image:
     registry: "docker.io"           # Image global registry, opencsg-registry.cn-beijing.cr.aliyuncs.com for mainland
     registryPolicy: "default"       # default or force, force will overwrite all others registries
-    tag: "v2.1.0"                   # Image tag format: {{version}}-{{edition}}
+    tag: "v2.2.0"                   # Image tag format: {{version}}-{{edition}}
     pullPolicy: "IfNotPresent"      # Image pull policy: Always, IfNotPresent, Never
     pullSecrets: []                 # Private registry authentication secrets
 
@@ -74,7 +74,7 @@ externalUrl: "https://csghub.example.com"
 image:
   # registry: "docker.io"                    # Docker registry
   repository: "opencsghq/csghub-server"
-  tag: "v2.1.0"                            # Image version tag
+  tag: "v2.2.0"                            # Image version tag
   pullPolicy: "IfNotPresent"               # Image pull policy: Always, IfNotPresent, Never
   pullSecrets: []                          # Docker registry secrets
 


### PR DESCRIPTION
## Summary
- Bump runner chart version from 2.1.2 to 2.2.0
- Bump appVersion from v2.1.0 to v2.2.0
- Update image tag from v2.1.0 to v2.2.0

## Test plan
- [ ] ct lint passed
- [ ] All unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)