### PR TITLE
feat(loki): add max_concurrent_tail_requests config

### DIFF
--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -897,6 +897,8 @@ loki:
       enabled: false                       # Disable tracing
     querier:
       max_concurrent: 40                   # Maximum concurrent queries
+    limits_config:
+      max_concurrent_tail_requests: 40     # Maximum concurrent tail requests
 
   test:
     enabled: false                         # Disable test configuration


### PR DESCRIPTION
Add `loki.loki.limits_config.max_concurrent_tail_requests: 40` to align tail request concurrency with the existing `querier.max_concurrent: 40` limit.

Helps prevent tail request saturation when concurrent tail streams ramp up.