### PR TITLE
Update agentichub

### DIFF
--- a/charts/agentichub/Chart.yaml
+++ b/charts/agentichub/Chart.yaml
@@ -16,13 +16,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.5.1"
+appVersion: "v0.6.1"
 
 # Defined dependencies for subChart
 dependencies:

--- a/charts/agentichub/templates/agenticflow/job.yaml
+++ b/charts/agentichub/templates/agenticflow/job.yaml
@@ -38,7 +38,7 @@ spec:
 {{- end }}
       containers:
         - name: importer
-          image: {{ include "common.image.fixed" (dict "ctx" . "service" "agenticflow" "image" "opencsghq/agenticflow-importer:latest") }}
+          image: {{ include "common.image.fixed" (dict "ctx" . "service" "agenticflow" "image" "opencsghq/agenticflow-importer:v1.0.4") }}
           imagePullPolicy: {{ or $service.image.pullPolicy .Values.global.image.pullPolicy }}
           envFrom:
             - configMapRef:

--- a/charts/agentichub/templates/csgbot/configmap.yaml
+++ b/charts/agentichub/templates/csgbot/configmap.yaml
@@ -17,11 +17,12 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
 data:
   csgbot.toml: |
-    [database]
-    file = "agno.db"
+    [environment]
+    name = "ee"
+    project-path = "/root/csgbot"
+    base-path = "/data/"
 
     [credentials]
-    aigateway-access-token = ""
     {{- $apiToken := .Values.hubAPIToken }}
     {{- if $isBuiltIn }}
       {{- $csghubSvc := include "common.names.custom" (list . "core") }}
@@ -34,59 +35,86 @@ data:
     {{- $data := (lookup "v1" "ConfigMap" .Release.Namespace $agenticSvcName).data | default dict }}
     {{- $agenticflowToken := dig "FLOWS_ACCESS_TOKEN" (include "agenticflow.api.token" .) $data }}
     langflow-access-token = {{ $agenticflowToken | quote }}
-    web-search-api-key = {{ dig "config" "webSearch" "apiKey" "" .Values.csgbot | quote }}
 
-    [opencsg]
+    [csghub]
     {{- $csghubEndpoint := .Values.externalUrl }}
     {{- if $isBuiltIn }}
       {{- $csghubEndpoint = include "common.endpoint.csghub" . }}
     {{- end }}
-    hub-base-url = {{ $csghubEndpoint | quote }}
-    base-url = {{ $csghubEndpoint | quote }}
-    mcp-gateway-url = {{ printf "%s/v1/gateway/mcp" (include "endpoint.aigateway" .) | quote }}
+    endpoint = {{ $csghubEndpoint | quote }}
+    portal-endpoint = {{ $csghubEndpoint | quote }}
+    starship-endpoint = {{ dig "config" "starship" "endpoint" "" .Values.csgbot | quote }}
+    mcp-gateway-endpoint = {{ printf "%s/v1/gateway/mcp" (include "endpoint.aigateway" .) | quote }}
 
     [aigateway]
-    base-url = {{ include "endpoint.aigateway" . | quote }}
-    model-id = {{ dig "config" "aigateway" "model" "deepseek-v3" .Values.csgbot | quote }}
+    endpoint = {{ include "endpoint.aigateway" . | quote }}
+    model-id = {{ dig "config" "aigateway" "model" "qwen3.6-plus" .Values.csgbot | quote }}
+    temperature = {{ dig "config" "aigateway" "temperature" 0.1 .Values.csgbot }}
+
+    [speech-to-text]
+    model-id = {{ dig "config" "speechToText" "modelId" "qwen3-asr-flash" .Values.csgbot | quote }}
+    api-mode = {{ dig "config" "speechToText" "apiMode" "chat-completions" .Values.csgbot | quote }}
+    prompt = {{ dig "config" "speechToText" "prompt" "" .Values.csgbot | quote }}
+    response-format = {{ dig "config" "speechToText" "responseFormat" "json" .Values.csgbot | quote }}
+    max-file-bytes = {{ dig "config" "speechToText" "maxFileBytes" "26214400" .Values.csgbot | quote }}
+    forward-timeout-seconds = {{ dig "config" "speechToText" "forwardTimeoutSeconds" 120.0 .Values.csgbot }}
 
     [langflow]
-    base-url = {{ include "common.endpoint.agenticflow" . | quote }}
+    endpoint = {{ include "common.endpoint.agenticflow" . | quote }}
 
-    [integrations]
-    feishu-notification-enabled = {{ dig "config" "integrations" "feishuEnabled" false .Values.csgbot | quote }}
-    notification-url = {{ printf "%s/api/v1/notifications?current_user=csgbot" $csghubEndpoint | quote }}
-    {{- $memSvc := include "common.service" (dict "ctx" . "service" "memmachine") | fromYaml }}
-    {{- $memsSvcName := include "common.names.custom" (list . $memSvc.name) }}
-    memmachine-url = {{ printf "http://%s:8080/mcp/" $memsSvcName | quote }}
-
-    [logging]
-    log-path = "logs/server.log"
-    disable-genius-chat = {{ dig "config" "logging" "disableGeniusChat" false .Values.csgbot }}
-
-    [genius-sandbox]
-    sandbox-backend = "csghub"
-    sandbox-image = {{ include "common.image" (list . (dig "config" "sandbox" "genius" "image" dict .Values.csgbot)) | quote }}
+    [sandbox]
+    backend = "csghub"
+    legacy-endpoint = ""
     workspace-volume-prefix = "/genius"
+    timeout-seconds = {{ dig "config" "sandbox" "timeoutSeconds" 600 .Values.csgbot }}
+    max-upload-file-bytes = {{ dig "config" "sandbox" "maxUploadFileBytes" 52428800 .Values.csgbot }}
 
-    [doc-sandbox]
+    [sandbox.genius]
+    backend = "csghub"
+    legacy-endpoint = ""
+    workspace-volume-prefix = "/genius"
+    timeout-seconds = {{ dig "config" "sandbox" "timeoutSeconds" 600 .Values.csgbot }}
+    max-upload-file-bytes = {{ dig "config" "sandbox" "maxUploadFileBytes" 52428800 .Values.csgbot }}
+    image = {{ include "common.image" (list . (dig "config" "sandbox" "genius" "image" dict .Values.csgbot)) | quote }}
+
+    [sandbox.doc]
     # Docs are baked into the doc sandbox image; the doc sandbox reuses the same
     # sandbox-service-url as genius-sandbox.
+    backend = "csghub"
+    timeout-seconds = {{ dig "config" "sandbox" "timeoutSeconds" 600 .Values.csgbot }}
     image = {{ include "common.image" (list . (dig "config" "sandbox" "doc" "image" dict .Values.csgbot)) | quote }}
 
-    [external-docs]
-    enabled = {{ dig "config" "externalDocs" "enabled" false .Values.csgbot }}
-
-    [external-docs.apis]
-    "CSGHUB" = "{{ $csghubEndpoint }}/api/v1/swagger/doc.json"
-
-    [web-search]
-    # Web search API configuration for web fetch tool
-    api-url = {{ dig "config" "webSearch" "apiUrl" "" .Values.csgbot | quote }}
-
-    [csghub-sandbox]
-    base-url = {{ $csghubEndpoint | quote }}
-    aigateway-url = {{ include "endpoint.aigateway" . | quote }}
-
-    [openclaw-sandbox]
+    [sandbox.openclaw]
     image = {{ include "common.image" (list . (dig "config" "sandbox" "openclaw" "image" dict .Values.csgbot)) | quote }}
+
+    [sandbox.csgclaw-server]
+    image = {{ include "common.image" (list . (dig "config" "sandbox" "csgclawServer" "image" dict .Values.csgbot)) | quote }}
+
+    [sandbox.csgclaw-agent]
+    image = {{ include "common.image" (list . (dig "config" "sandbox" "csgclawAgent" "image" dict .Values.csgbot)) | quote }}
+
+    [integrations]
+    notifications-enabled = {{ dig "config" "integrations" "notification" "enabled" false .Values.csgbot | quote }}
+    notification-endpoint = {{ printf "%s/api/v1/notifications?current_user=csgbot" $csghubEndpoint | quote }}
+    {{- $memSvc := include "common.service" (dict "ctx" . "service" "memmachine") | fromYaml }}
+    {{- $memsSvcName := include "common.names.custom" (list . $memSvc.name) }}
+    memmachine-endpoint = {{ printf "http://%s:8080/mcp/" $memsSvcName | quote }}
+    file-server-endpoint = {{ dig "config" "fileServer" "endpoint" "" .Values.csgbot | quote }}
+
+    [observability]
+    service-name = {{ dig "config" "observability" "serviceName" "csgbot-ee" .Values.csgbot | quote }}
+    phoenix-endpoint = {{ dig "config" "observability" "phoenixEndpoint" "" .Values.csgbot | quote }}
+    otlp-traces-endpoint = {{ dig "config" "observability" "otlpTracesEndpoint" "" .Values.csgbot | quote }}
+    otlp-insecure = {{ dig "config" "observability" "otlpInsecure" true .Values.csgbot }}
+    otlp-protocol = {{ dig "config" "observability" "otlpProtocol" "grpc" .Values.csgbot | quote }}
+
+    [logging]
+    log-path = {{ dig "config" "logging" "logPath" "logs/server.log" .Values.csgbot | quote }}
+    log-level = {{ dig "config" "logging" "logLevel" "INFO" .Values.csgbot | quote }}
+    disable-genius-chat = {{ dig "config" "logging" "disableGeniusChat" false .Values.csgbot }}
+    disable-planner-chat = {{ dig "config" "logging" "disablePlannerChat" false .Values.csgbot }}
+
+    [user-facing-errors]
+    # Shown when AI Gateway returns platform quota exhausted (403). Replace with customer IT contact.
+    platform-quota-maintenance-contact = {{ dig "config" "userFacingErrors" "platformQuotaMaintenanceContact" "" .Values.csgbot | quote }}
 {{- end }}

--- a/charts/agentichub/values.yaml
+++ b/charts/agentichub/values.yaml
@@ -123,7 +123,7 @@ agenticflow:
   image:
     # registry: "docker.io"
     repository: "opencsghq/agenticflow"
-    tag: "v0.5.1-ee"
+    tag: "ee-v0.6-4"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
 
@@ -170,7 +170,7 @@ csgbot:
   image:
     # registry: "docker.io"
     repository: "opencsghq/csgbot"
-    tag: "v0.5.1-ee"
+    tag: "v0.6.2-ee"
     pullPolicy: "IfNotPresent"
     pullSecrets: []
 
@@ -183,31 +183,72 @@ csgbot:
 
   ## ConfigMap Configuration
   config:
-    webSearch: {}
-      # apiUrl: "https://searchapi.xiaosuai.com/search/..."
-      # apiKey: ""
+    aigateway: {}
+      # model: "qwen3.6-plus"       # AI model ID for csgbot
+      # temperature: 0.1            # Model temperature
+
+    starship: {}
+      # endpoint: ""                # Starship endpoint URL
+
+    speechToText: {}
+      # modelId: "qwen3-asr-flash"
+      # apiMode: "chat-completions"
+      # prompt: ""
+      # responseFormat: "json"
+      # maxFileBytes: "26214400"
+      # forwardTimeoutSeconds: 120.0
+
     integrations: {}
-      # feishuEnabled: false
-    logging: {}
-      # disableGeniusChat: false
+      # notification:
+        # enabled: false
+
+    fileServer: {}
+      # endpoint: ""                # File server endpoint URL
+
     sandbox:
+      # timeoutSeconds: 600
+      # maxUploadFileBytes: 52428800
       genius:
         image:
           # registry: "docker.io"
           repository: "opencsghq/genius-sandbox"
-          tag: "20260430v1"
+          tag: "58acc91d"
       doc:
         image:
           # registry: "docker.io"
           repository: "opencsghq/doc-sandbox"
-          tag: "20260416.2"
+          tag: "03c2897c"
       openclaw:
         image:
           # registry: "docker.io"
           repository: "opencsghq/openclaw-sandbox"
-          tag: "20260408.4"
-    externalDocs: {}
-      # enabled: false    # APIS Need turn on csghub swaggerAPI docs
+          tag: "03c2897c"
+      csgclawServer:
+        image:
+          # registry: "docker.io"
+          repository: "opencsghq/csgclaw-server-sandbox"
+          tag: "2026060701"
+      csgclawAgent:
+        image:
+          # registry: "docker.io"
+          repository: "opencsghq/csgclaw-agent-sandbox"
+          tag: "2026060301"
+
+    logging: {}
+      # logPath: "logs/server.log"
+      # logLevel: "INFO"
+      # disableGeniusChat: false
+      # disablePlannerChat: false
+
+    observability: {}
+      # serviceName: "csgbot-ee"
+      # phoenixEndpoint: ""
+      # otlpTracesEndpoint: ""
+      # otlpInsecure: true
+      # otlpProtocol: "grpc"
+
+    userFacingErrors: {}
+      # platformQuotaMaintenanceContact: ""   # Contact info shown on 403 quota errors
 
 #################################################################
 ##  Built-in Third-party Components                            ##

--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -31,6 +31,6 @@ dependencies:
   version: 1.6.7
 - name: agentichub
   repository: https://charts.opencsg.com/csghub
-  version: 0.5.1
-digest: sha256:21692e95610398a010151d0515adb04fb8d4acb039af350136a2f0f7ea0afc77
-generated: "2026-06-10T22:20:16.35707+08:00"
+  version: 0.6.1
+digest: sha256:c9520aea40de0680092568300d610507c1f29b386737ea67a79a37feca8a8350
+generated: "2026-06-15T12:47:19.899921+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -73,6 +73,6 @@ dependencies:
     repository: oci://docker.io/envoyproxy
     condition: envoy.enabled
   - name: agentichub
-    version: 0.5.1
+    version: 0.6.1
     repository: https://charts.opencsg.com/csghub
     condition: agentichub.enabled


### PR DESCRIPTION
## What

Bump `agentichub` subchart `0.5.1` → `0.6.1` and align the csghub umbrella chart dependency + lock. Update `csgbot` config to match the new `v0.6.x` configuration schema.

## Why

`agentichub` 0.6.x ships a redesigned `csgbot.toml` schema (new `csghub`/`aigateway` key names, split sandbox config, observability + speech-to-text blocks) and new sandbox images. The chart must follow so the rendered ConfigMap stays valid.

## Changes

- `charts/agentichub/Chart.yaml`: `version 0.5.1 → 0.6.1`, `appVersion v0.5.1 → v0.6.1`.
- `charts/agentichub/templates/agenticflow/job.yaml`: pin importer image `latest` → `v1.0.4`.
- `charts/agentichub/templates/csgbot/configmap.yaml`: rewrite `csgbot.toml` to the new schema:
  - Rename key set: `[opencsg]` → `[csghub]` (`hub-base-url`/`base-url`/`mcp-gateway-url` → `endpoint`/`portal-endpoint`/`mcp-gateway-endpoint`).
  - `[aigateway]`: `base-url` → `endpoint`; add `temperature`.
  - New blocks: `[environment]`, `[speech-to-text]`, `[sandbox]` (+ `genius` / `doc` / `openclaw` / `csgclaw-server` / `csgclaw-agent`), `[observability]`, `[user-facing-errors]`.
  - Remove obsolete `[database]`, `[external-docs]`, `[web-search]`, `[csghub-sandbox]`, `[openclaw-sandbox]` blocks.
  - All values now read via `dig` against `csgbot.config.*` with sensible defaults — no `nil` panics on missing keys.
- `charts/agentichub/values.yaml`:
  - `agenticflow.image.tag`: `v0.5.1-ee` → `ee-v0.6-4`.
  - `csgbot.image.tag`: `v0.5.1-ee` → `v0.6.2-ee`.
  - `csgbot.config`: rewrite to match new ConfigMap schema (aigateway / starship / speechToText / integrations / fileServer / sandbox / logging / observability / userFacingErrors).
  - Sandbox image tags: `genius` `20260430v1` → `58acc91d`; `doc` `20260416.2` → `03c2897c`; `openclaw` `20260408.4` → `03c2897c`. Add `csgclawServer` (`2026060701`) and `csgclawAgent` (`2026060301`).
- `charts/csghub/Chart.yaml` + `Chart.lock`: bump `agentichub` dep `0.5.1` → `0.6.1`, regen lock digest.

## Compatibility

- Existing `csgbot.config.webSearch`, `externalDocs`, `logging.disableGeniusChat` keys are no longer rendered. Operators relying on them must migrate to the new keys before upgrading.
- All new keys are read with `dig` + defaults, so a fresh `helm install` works out of the box.
- No public service / port / RBAC changes.

## Verification

- `helm dependency update charts/csghub` → Chart.lock regenerated.
- `helm lint charts/agentichub` clean.
- `helm template agentichub charts/agentichub` renders valid `csgbot.toml` against the new schema.
