### PR TITLE
feat: add allowCpuOnGpuNodes config for csghub

### DIFF
--- a/charts/csghub/templates/csghub/configmap.yaml
+++ b/charts/csghub/templates/csghub/configmap.yaml
@@ -388,6 +388,9 @@ data:
   ## Server Configuration for S3 Proxy
   STARHUB_SERVER_STORAGE_GATEWAY_ENABLE_PRESIGNED_URL_PROXY: {{ $serverSvc.enablePresignedUrlProxy | quote }}
 
+  ## Cluster Scheduling Configuration
+  STARHUB_SERVER_CLUSTER_ALLOW_CPU_RESOURCE_SCHEDULE_TO_GPU_NODE: {{ $serverSvc.allowCpuOnGpuNodes | quote }}
+
   ## Define default error redirect URL
   STARHUB_SERVER_FAIL_REDIRECT_URL: {{ printf "%s/errors/server-error" (include "common.endpoint.csghub" .) }}
   ## Additional environments for all csghub deployments

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -243,6 +243,10 @@ server:
   ## S3 Proxy
   enablePresignedUrlProxy: true            # Enable S3 proxy
 
+  ## Cluster Scheduling Configuration
+  ## Allow CPU resource requests to be scheduled on GPU nodes
+  allowCpuOnGpuNodes: false
+
   ## Agentichub configuration
   agenticflow: {}
     # host: "http://agenticflow.example.io" # AgentHub address


### PR DESCRIPTION
## What

Add `STARHUB_SERVER_CLUSTER_ALLOW_CPU_RESOURCE_SCHEDULE_TO_GPU_NODE` environment variable to csghub server ConfigMap, gated by a new `server.allowCpuOnGpuNodes` value.

## Why

By default, Kubernetes resource scheduling does not distinguish CPU and GPU node pools. When CPU-only pods get scheduled onto GPU nodes, GPUs sit idle but cannot be used by GPU workloads. This flag tells the csghub backend to explicitly prevent (or allow) CPU resource requests from landing on GPU-labeled nodes, giving operators control over GPU node utilisation.

## Changes

- `charts/csghub/values.yaml`: add `server.allowCpuOnGpuNodes` (default: `false`).
- `charts/csghub/templates/csghub/configmap.yaml`: render `STARHUB_SERVER_CLUSTER_ALLOW_CPU_RESOURCE_SCHEDULE_TO_GPU_NODE` from the new value.

## Compatibility

- Default `false` — existing behaviour unchanged. No migration needed.
- Operators who need CPU pods on GPU nodes set it to `true`.

## Verification

- `helm template csghub charts/csghub` — ConfigMap contains the new env var set to `false`.
- Override via `--set server.allowCpuOnGpuNodes=true` — value toggles correctly.
