### PR TITLE
fix: enable csgship HTTPRoutes in bundled mode (0.4.2)

### DIFF
--- a/charts/csgship/Chart.yaml
+++ b/charts/csgship/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.1
+version: 0.4.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/csgship/templates/frontend/httproutes.yaml
+++ b/charts/csgship/templates/frontend/httproutes.yaml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $service := include "common.service" (dict "ctx" . "service" "frontend") | fromYaml }}
 {{- $gatewayConfig := include "common.gateway.config" (dict "ctx" . "service" $service) | fromYaml }}
-{{- if and $gatewayConfig.enabled (not .Values.global.chartContext.isBuiltIn) }}
+{{- if $gatewayConfig.enabled }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/charts/csgship/templates/web/httproutes.yaml
+++ b/charts/csgship/templates/web/httproutes.yaml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $service := include "common.service" (dict "ctx" . "service" "web") | fromYaml }}
 {{- $gatewayConfig := include "common.gateway.config" (dict "ctx" . "service" $service) | fromYaml }}
-{{- if and $gatewayConfig.enabled (not .Values.global.chartContext.isBuiltIn) }}
+{{- if $gatewayConfig.enabled }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute

--- a/charts/csgship/values.yaml
+++ b/charts/csgship/values.yaml
@@ -172,6 +172,10 @@ frontend:
     repository: "opencsghq/csgship-portal"
     tag: "v1.2.1"
 
+  ## Gateway configuration
+  gateway:
+    enabled: true                            # Enable or disable gateway
+
 ## MegaLinter Server Configuration
 megalinterServer:
   image:


### PR DESCRIPTION
## Summary

- Remove `isBuiltIn` guard from csgship `frontend/httproutes.yaml` and `web/httproutes.yaml` so HTTPRoutes render when csgship is deployed as a subchart of csghub (`csgship.enabled=true`)
- Add missing `gateway.enabled: true` for frontend service in values.yaml (was defaulting to false, double-blocking the frontend HTTPRoute)
- Bump csgship chart version to 0.4.2

## Background

The `not .Values.global.chartContext.isBuiltIn` guard was copied from the runner chart when csgship migrated from Ingress to Gateway API (45219f6f). Unlike runner and dataflow, the parent csghub chart has no routing rules for csgship services, so the guard caused all csgship HTTPRoutes to be skipped in bundled mode — leaving csgship with no traffic entry point.

### Files changed

| File | Change |
|---|---|
| `csgship/templates/frontend/httproutes.yaml` | Remove `isBuiltIn` guard |
| `csgship/templates/web/httproutes.yaml` | Remove `isBuiltIn` guard |
| `csgship/values.yaml` | Add `frontend.gateway.enabled: true` |
| `csgship/Chart.yaml` | `0.4.1` → `0.4.2` |

Casdoor HTTPRoute and Gateway/GatewayClass templates retain the `isBuiltIn` guard (parent chart already provides these).

## Test plan

- [x] helm template rendering passes
- [x] helm unittest passes (121 tests for csghub, 25 for csgship)
- [x] ct lint passes
- [x] YAML validation passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)