### PR TITLE
fix: lookup API token from csghub-core first in csgship

### DIFF
--- a/charts/csgship/Chart.yaml
+++ b/charts/csgship/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/csgship/templates/configmap.yaml
+++ b/charts/csgship/templates/configmap.yaml
@@ -58,7 +58,9 @@ data:
   ## Web Configuration for Accounting
   # ACCOUNTING_OP_MODE: "has_balance|consume"
   ACCOUNTING_OP_MODE: ""
-  {{- $apiToken := dig "ACCOUNTING_API_KEY" (include "csghub.api.token" .) $data }}
+  {{- $csghubSvc := include "common.names.custom" (list . "core") }}
+  {{- $csghubData := (lookup "v1" "ConfigMap" .Release.Namespace $csghubSvc).data | default dict }}
+  {{- $apiToken := dig "STARHUB_SERVER_API_TOKEN" (dig "ACCOUNTING_API_KEY" (include "csghub.api.token" .) $data) $csghubData }}
   {{- if .Values.global.chartContext.isBuiltIn }}
   ACCOUNTING_API_BASE: {{ include "common.endpoint.csghub" . | quote }}
   ACCOUNTING_API_KEY: {{ $apiToken | quote }}


### PR DESCRIPTION
## Summary
- Lookup `STARHUB_SERVER_API_TOKEN` from `csghub-core` ConfigMap first, then fall back to `ACCOUNTING_API_KEY` from csgship's own ConfigMap
- Bump csgship chart version to 0.4.3

## Test plan
- [ ] Verify csgship unit tests pass
- [ ] Verify helm template renders correctly