### PR TITLE
fix: rename envoy-proxy-custom to envoy-proxy in agentichub csgship dataflow

### DIFF
--- a/charts/agentichub/templates/envoy-proxy.yaml
+++ b/charts/agentichub/templates/envoy-proxy.yaml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $gateway := .Values.global.gateway }}
 {{- if and (ne .Values.global.edition "ce") (not .Values.global.chartContext.isBuiltIn) (regexMatch "envoyproxy" $gateway.controllerName) }}
-{{- $serviceName := include "common.names.custom" (list . "envoy-proxy-custom") }}
+{{- $serviceName := include "common.names.custom" (list . "envoy-proxy") }}
 {{- $gatewayConfig := include "common.gateway.config" (dict "ctx" . "service" dict) | fromYaml }}
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy

--- a/charts/agentichub/templates/gateway.yaml
+++ b/charts/agentichub/templates/gateway.yaml
@@ -24,7 +24,7 @@ spec:
     parametersRef:
       group: gateway.envoyproxy.io
       kind: EnvoyProxy
-      name: {{ include "common.names.custom" (list . "envoy-proxy-custom") }}
+      name: {{ include "common.names.custom" (list . "envoy-proxy") }}
   {{- end }}
   listeners:
     - name: http

--- a/charts/csgship/templates/envoy-proxy.yaml
+++ b/charts/csgship/templates/envoy-proxy.yaml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $gateway := .Values.global.gateway }}
 {{- if and (regexMatch "envoyproxy" $gateway.controllerName) (not .Values.global.chartContext.isBuiltIn) }}
-{{- $serviceName := include "common.names.custom" (list . "envoy-proxy-custom") }}
+{{- $serviceName := include "common.names.custom" (list . "envoy-proxy") }}
 {{- $gatewayConfig := include "common.gateway.config" (dict "ctx" . "service" dict) | fromYaml }}
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy
@@ -48,11 +48,5 @@ spec:
                   targetPort: 10443
                   nodePort: {{ $gatewayConfig.service.nodePorts.https }}
                 {{- end }}
-                {{- $serverSvc := include "common.service" (dict "ctx" . "service" "server") | fromYaml }}
-                {{- $sshPort := dig "gitlabShell" "sshPort" 22 $serverSvc }}
-                - name: {{ printf "tcp-%v" $sshPort }}
-                  port: {{ $sshPort }}
-                  targetPort: {{ if le (len (printf "%v" $sshPort)) 3 }}{{ printf "10%03d" (int $sshPort) }}{{ else }}{{ $sshPort }}{{ end }}
-                  nodePort: {{ $gatewayConfig.service.nodePorts.gitssh }}
       {{- end }}
 {{- end }}

--- a/charts/csgship/templates/gateway.yaml
+++ b/charts/csgship/templates/gateway.yaml
@@ -24,7 +24,7 @@ spec:
     parametersRef:
       group: gateway.envoyproxy.io
       kind: EnvoyProxy
-      name: {{ include "common.names.custom" (list . "envoy-proxy-custom") }}
+      name: {{ include "common.names.custom" (list . "envoy-proxy") }}
   {{- end }}
   listeners:
     - name: http

--- a/charts/dataflow/templates/envoy-proxy.yaml
+++ b/charts/dataflow/templates/envoy-proxy.yaml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $gateway := .Values.global.gateway }}
 {{- if and (regexMatch "envoyproxy" $gateway.controllerName) (not .Values.global.chartContext.isBuiltIn) }}
-{{- $serviceName := include "common.names.custom" (list . "envoy-proxy-custom") }}
+{{- $serviceName := include "common.names.custom" (list . "envoy-proxy") }}
 {{- $gatewayConfig := include "common.gateway.config" (dict "ctx" . "service" dict) | fromYaml }}
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: EnvoyProxy

--- a/charts/dataflow/templates/gateway.yaml
+++ b/charts/dataflow/templates/gateway.yaml
@@ -24,7 +24,7 @@ spec:
     parametersRef:
       group: gateway.envoyproxy.io
       kind: EnvoyProxy
-      name: {{ include "common.names.custom" (list . "envoy-proxy-custom") }}
+      name: {{ include "common.names.custom" (list . "envoy-proxy") }}
   {{- end }}
   listeners:
     - name: http


### PR DESCRIPTION
## Summary
- Rename `envoy-proxy-custom` to `envoy-proxy` in agentichub, csgship, dataflow envoy-proxy and gateway templates
- Remove unused server/gitlab SSH port mapping from csgship envoy-proxy (not applicable to csgship)

## Charts
- agentichub
- csgship (including standalone helm/csgship)
- dataflow