### PR TITLE
feat: sync runner value restructuring to csghub chart

### DIFF
--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -22,7 +22,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.1
+version: 2.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/csghub/templates/csghub/configmap.yaml
+++ b/charts/csghub/templates/csghub/configmap.yaml
@@ -239,11 +239,12 @@ data:
 
   ## Server Configuration for Model
   {{- $runnerSvc := include "common.service" (dict "ctx" . "service" "runner") | fromYaml }}
-  STARHUB_SERVER_MODEL_DEPLOY_TIMEOUT_IN_MINUTES: {{ $runnerSvc.model.deployTimeout | default 60 | quote }}
+  STARHUB_SERVER_MODEL_DEPLOY_TIMEOUT_IN_MINUTES: {{ $runnerSvc.model.deployTimeoutInMin | default 60 | quote }}
   STARHUB_SERVER_MODEL_DOWNLOAD_ENDPOINT: {{ include "common.endpoint.csghub" . | quote }}
   ## Server Configuration for Model
-  {{- $registry := or $runnerSvc.model.registry .Values.global.image.registry "docker.io" }}
+  {{- $registry := or $runnerSvc.model.dockerRegBase .Values.global.image.registry "docker.io" }}
   STARHUB_SERVER_MODEL_DOCKER_REG_BASE: {{ $registry | quote }}
+  STARHUB_SERVER_MODEL_DEPLOY_STATUS_CHECK_INTERVAL: {{ $runnerSvc.model.deployStatusCheckInterval | default 10 | quote }}
   STARHUB_SERVER_SPACE_BUILD_TIMEOUT_IN_MINUTES: {{ $serverSvc.space.buildTimeout | default 30 | quote }}
 
   ## Server Configuration for Multiple-Sync
@@ -293,15 +294,13 @@ data:
   {{- $rproxyPort := dig "service" "port" 8083 $rproxySvc }}
   STARHUB_SERVER_INTERNAL_ROOT_DOMAIN: {{ printf "%s.app.internal:%v" (include "namespace.spaces" .) $rproxyPort | quote }}
   {{- $endpoint := include "common.endpoint.public" . | trimPrefix "http://" | trimPrefix "https://" }}
-  STARHUB_SERVER_PUBLIC_ROOT_DOMAIN: {{ ternary $endpoint "" $runnerSvc.usePublicDomain | quote }}
-  STARHUB_SERVER_SPACE_PYPI_INDEX_URL: {{ $runnerSvc.pipIndexUrl | quote }}
-  {{- if $runnerSvc.volcano.enabled }}
-  STARHUB_SERVER_RUNNER_KUBE_SCHEDULER: "volcano"
-  STARHUB_SERVER_RUNNER_VGPU_NODE_RESOURCE_NAME: "volcano.sh/node-vgpu-register"
-  STARHUB_SERVER_RUNNER_VGPU_POD_RESOURCE_NAME: "volcano.sh/vgpu-ids-new"
-  STARHUB_SERVER_RUNNER_VGPU_RESOURCE_REQ_KEY: "volcano.sh/vgpu-number"
-  STARHUB_SERVER_RUNNER_VGPU_MEMORY_REQ_KEY: "volcano.sh/vgpu-memory"
-  {{- end }}
+  STARHUB_SERVER_PUBLIC_ROOT_DOMAIN: {{ ternary $endpoint "" $runnerSvc.space.usePublicDomain | quote }}
+  STARHUB_SERVER_SPACE_PYPI_INDEX_URL: {{ $runnerSvc.space.pipIndexUrl | quote }}
+  STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES: {{ $runnerSvc.space.deployTimeoutInMin | default 30 | quote }}
+  STARHUB_SERVER_SPACE_STATUS_CHECK_INTERVAL: {{ $runnerSvc.space.statusCheckInterval | default 10 | quote }}
+  {{- $typeLabel := $runnerSvc.space.gpuModelLabel.typeLabel }}
+  {{- $capacityLabel := $runnerSvc.space.gpuModelLabel.capacityLabel }}
+  STARHUB_SERVER_GPU_MODEL_LABEL: '[{"type_label": {{ $typeLabel | quote }}, "capacity_label": {{ $capacityLabel | quote }}}]'
   {{- $sessionToken := dig "STARHUB_SERVER_SPACE_SESSION_SECRET_KEY" (randNumeric 8 | sha1sum) $data }}
   STARHUB_SERVER_SPACE_SESSION_SECRET_KEY: {{ $sessionToken | quote }}
 

--- a/charts/csghub/templates/csghub/httproutes-wildcard.yaml
+++ b/charts/csghub/templates/csghub/httproutes-wildcard.yaml
@@ -6,7 +6,7 @@ SPDX-License-Identifier: APACHE-2.0
 {{- $service := include "common.service" (dict "ctx" . "service" "rproxy") | fromYaml }}
 {{- $runnerSvc := include "common.service" (dict "ctx" . "service" "runner") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
-{{- if $runnerSvc.usePublicDomain }}
+{{- if $runnerSvc.space.usePublicDomain }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/csghub/templates/csghub/httproutes.yaml
+++ b/charts/csghub/templates/csghub/httproutes.yaml
@@ -148,7 +148,7 @@ spec:
     {{- $runnerSvc := include "common.service" (dict "ctx" . "service" "runner") | fromYaml }}
     {{- $rproxySvc := include "common.service" (dict "ctx" . "service" "rproxy") | fromYaml }}
     {{- $rproxySvcName := include "common.names.custom" (list . $rproxySvc.name) }}
-    {{- if not $runnerSvc.usePublicDomain }}
+    {{- if not $runnerSvc.space.usePublicDomain }}
     - matches:
         - path:
             type: PathPrefix

--- a/charts/csghub/tests/configmap_test.yaml
+++ b/charts/csghub/tests/configmap_test.yaml
@@ -32,18 +32,24 @@ set:
       port: "8070"
   runner:
     name: "runner-svc"
-    namespace: "spaces"
-    interval: 30
-    region: "cn-north-1"
-    usePublicDomain: true
+    runner:
+      namespace: "spaces"
+      interval: 30
+      region: "cn-north-1"
     model:
-      deployTimeout: "120"
-      registry: "model.io"
+      deployTimeoutInMin: "120"
+      dockerRegBase: "model.io"
+      deployStatusCheckInterval: "10"
+    space:
+      usePublicDomain: true
+      pipIndexUrl: "https://pypi.tuna.tsinghua.edu.cn/simple/"
+      deployTimeoutInMin: "30"
+      statusCheckInterval: "10"
+      gpuModelLabel:
+        typeLabel: "nvidia.com/gpu.product"
+        capacityLabel: "nvidia.com/gpu"
     service:
       port: 8072
-    gpuModelLabel:
-      typeLabel: "nvidia.com/gpu.product"
-      capacityLabel: "nvidia.com/gpu"
   accounting:
     name: "accounting-svc"
   user:
@@ -123,6 +129,21 @@ tests:
       - equal:
           path: data.STARHUB_SERVER_MODEL_DOCKER_REG_BASE
           value: "model.io"
+      - equal:
+          path: data.STARHUB_SERVER_MODEL_DEPLOY_STATUS_CHECK_INTERVAL
+          value: "10"
+      - equal:
+          path: data.STARHUB_SERVER_SPACE_PYPI_INDEX_URL
+          value: "https://pypi.tuna.tsinghua.edu.cn/simple/"
+      - equal:
+          path: data.STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES
+          value: "30"
+      - equal:
+          path: data.STARHUB_SERVER_SPACE_STATUS_CHECK_INTERVAL
+          value: "10"
+      - equal:
+          path: data.STARHUB_SERVER_GPU_MODEL_LABEL
+          value: '[{"type_label": "nvidia.com/gpu.product", "capacity_label": "nvidia.com/gpu"}]'
       - matchRegex:
           path: data.STARHUB_DATABASE_DSN
           pattern: "postgresql://csghub:.*csghub-postgresql:5432/csghub_server_svc\\?sslmode=disable"
@@ -460,7 +481,8 @@ tests:
             secure: "false"
             pathStyle: "false"
       runner:
-        usePublicDomain: false
+        space:
+          usePublicDomain: false
     asserts:
       - equal:
           path: data.STARHUB_SERVER_PUBLIC_ROOT_DOMAIN

--- a/charts/csghub/values.schema.json
+++ b/charts/csghub/values.schema.json
@@ -181,17 +181,45 @@
       "type": "object",
       "properties": {
         "enabled": {"type": "boolean"},
-        "region": {"type": "string"},
-        "interval": {"type": "integer"},
-        "namespace": {"type": "string"},
-        "mergingNamespace": {"type": "string"},
-        "usePublicDomain": {"type": "boolean"},
-        "pipIndexUrl": {"type": "string"},
-        "extraBuildArgs": {"type": "array", "items": {"type": "string"}},
-        "model": {"type": "object", "additionalProperties": true},
-        "gpuModelLabel": {"type": "object", "additionalProperties": true},
-        "applicationEndpoint": {"type": "string"},
-        "networkInterface": {"type": "string"},
+        "volcano": {"type": "object", "additionalProperties": true},
+        "runner": {
+          "type": "object",
+          "properties": {
+            "region": {"type": "string"},
+            "interval": {"type": "integer"},
+            "namespace": {"type": "string"},
+            "mergingNamespace": {"type": "string"},
+            "applicationEndpoint": {"type": "string"},
+            "networkInterface": {"type": "string"},
+            "storageClassName": {"type": "string"}
+          },
+          "additionalProperties": true
+        },
+        "model": {
+          "type": "object",
+          "properties": {
+            "deployTimeoutInMin": {"type": "string"},
+            "downloadEndpoint": {"type": "string"},
+            "dockerRegBase": {"type": "string"},
+            "deployStatusCheckInterval": {"type": "string"}
+          },
+          "additionalProperties": true
+        },
+        "space": {
+          "type": "object",
+          "properties": {
+            "usePublicDomain": {"type": "boolean"},
+            "pipIndexUrl": {"type": "string"},
+            "deployTimeoutInMin": {"type": "string"},
+            "buildTimeoutInMin": {"type": "string"},
+            "gpuModelLabel": {"type": "object", "additionalProperties": true},
+            "readinessDelaySeconds": {"type": "string"},
+            "readinessPeriodSeconds": {"type": "string"},
+            "readinessFailureThreshold": {"type": "string"},
+            "statusCheckInterval": {"type": "string"}
+          },
+          "additionalProperties": true
+        },
         "knative": {"type": "object", "additionalProperties": true},
         "logcollector": {"type": "object", "additionalProperties": true},
         "gateway": {"type": "object", "additionalProperties": true},

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -432,44 +432,47 @@ runner:
     enabled: false                       # Enable or disable volcano scheduler
 
   ## Runner operation and communication
-  region: "region-0"                     # Region the runner belongs to
-  interval: 60                           # Communication interval with server (seconds)
+  runner:
+    region: "region-0"                   # Region the runner belongs to
+    interval: 60                         # Communication interval with server (seconds)
 
-  ## Namespace management
-  namespace: "spaces"                    # Namespace for user-deployed workloads
-  mergingNamespace: "disable"            # Namespace merging: multi, single, disable
+    ## Namespace management
+    namespace: "spaces"                  # Namespace for user-deployed workloads
+    mergingNamespace: "disable"          # Namespace merging: multi, single, disable
 
-  ## Networking configuration
-  usePublicDomain: true                  # Use public domain for application access
+    # applicationEndpoint: ""            # Knative endpoint override (auto-detected if empty)
+    # networkInterface: ""               # Host network interface for distributed inference
+    # storageClassName: ""               # StorageClass for space persistent volumes
 
-  ## Package and image management
-  pipIndexUrl: "https://pypi.tuna.tsinghua.edu.cn/simple/"  # Custom pip repository
-  extraBuildArgs: []                     # Extra Kaniko build arguments
-  model:                                 # Model image configuration
-    deployTimeout: "60"                  # Timeout (in seconds) for model deployment operations
-    registry: ""                         # Custom image registry for model-related images (empty uses global registry)
+  ## Model deploy configuration
+  model:
+    deployTimeoutInMin: "60"             # Timeout (in minutes) for model deployment operations
+    # downloadEndpoint: ""               # Model download endpoint URL
+    # dockerRegBase: ""                  # Custom image registry for model images
+    # deployStatusCheckInterval: "10"    # Interval for checking model deploy status (seconds)
 
-  ## GPU resource configuration
-  gpuModelLabel:
-    typeLabel: "nvidia.com/gpu.product"  # GPU type label
-    capacityLabel: "nvidia.com/gpu"      # GPU capacity label
+  ## Space deploy configuration
+  space:
+    usePublicDomain: true                # Use public domain for application access
+    pipIndexUrl: "https://pypi.tuna.tsinghua.edu.cn/simple/"  # Custom pip repository
 
-  ## Knative networking configuration
-  ## e.g. http://<load balancer ip> or http://kourier-internal.kourier-system.svc.cluster.local
-  # applicationEndpoint: ""
+    # deployTimeoutInMin: "30"           # Timeout (in minutes) for space deployment operations
+    # buildTimeoutInMin: "30"            # Timeout (in minutes) for space build operations
 
-  ## Host network interface name used for inter-node communication during distributed (LWS) inference
-  ## e.g. eth0
-  # networkInterface: ""
+    ## GPU resource configuration
+    gpuModelLabel:
+      typeLabel: "nvidia.com/gpu.product"  # GPU type label
+      capacityLabel: "nvidia.com/gpu"      # GPU capacity label
 
-  ## Kubernetes StorageClass name for persistent volume provisioning for space
-  # Example values: "local-path", "gp2"
-  # storageClassName: ""
+    # readinessDelaySeconds: "120"       # Initial delay before readiness probe starts
+    # readinessPeriodSeconds: "10"       # Interval between readiness probe checks
+    # readinessFailureThreshold: "3"     # Consecutive failures before pod is marked unready
+    # statusCheckInterval: "10"          # Interval for checking space deployment status (seconds)
 
   ## Knative Serving configuration
   knative:
     serving:
-      domain: "example.com"               # Domain suffix for Knative services
+      domain: "example.com"              # Domain suffix for Knative services
 
       ## Ingress provider: "kourier" or "gateway-api"
       # ingress: "gateway-api"

--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.1
+version: 2.2.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/runner/templates/_runner.tpl
+++ b/charts/runner/templates/_runner.tpl
@@ -78,7 +78,7 @@ Returns:
     ) }}
   {{- end }}
 
-  {{- range $service.space.extraBuildArgs }}
+  {{- range $service.runner.imageBuilderKanikoArgs }}
     {{- $args = concat $args (list .) }}
   {{- end }}
 

--- a/charts/runner/templates/_runner.tpl
+++ b/charts/runner/templates/_runner.tpl
@@ -53,8 +53,8 @@ Returns:
   {{- $args := list "--compressed-caching=true" "--single-snapshot" "--log-format=text" }}
   {{- $args = concat $args (list "--cache=true" "--cache-ttl=24h" $kanikoCache) }}
 
-  {{- if $service.pipIndexUrl }}
-    {{- $args = concat $args (list (printf "--build-arg=PyPI=%s" $service.pipIndexUrl)) }}
+  {{- if $service.space.pipIndexUrl }}
+    {{- $args = concat $args (list (printf "--build-arg=PyPI=%s" $service.space.pipIndexUrl)) }}
   {{- end }}
 
   {{- $csghubEndpoint := $service.externalUrl }}
@@ -78,7 +78,7 @@ Returns:
     ) }}
   {{- end }}
 
-  {{- range $service.extraBuildArgs }}
+  {{- range $service.space.extraBuildArgs }}
     {{- $args = concat $args (list .) }}
   {{- end }}
 

--- a/charts/runner/templates/configmap.yaml
+++ b/charts/runner/templates/configmap.yaml
@@ -87,7 +87,7 @@ data:
   {{- $typeLabel := $service.space.gpuModelLabel.typeLabel }}
   {{- $capacityLabel := $service.space.gpuModelLabel.capacityLabel }}
   STARHUB_SERVER_GPU_MODEL_LABEL: '[{"type_label": {{ $typeLabel | quote }}, "capacity_label": {{ $capacityLabel | quote }}}]'
-  STARHUB_SERVER_MODEL_DEPLOY_TIMEOUT_IN_MINUTES: {{ $service.model.deployTimeout | default 60 | quote }}
+  STARHUB_SERVER_MODEL_DEPLOY_TIMEOUT_IN_MINUTES: {{ $service.model.deployTimeoutInMin | default 60 | quote }}
   ## Runner Configuration for Space Timeouts
   STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES: {{ $service.space.deployTimeoutInMin | default 30 | quote }}
   STARHUB_SERVER_SPACE_BUILD_TIMEOUT_IN_MINUTES: {{ $service.space.buildTimeoutInMin | default 30 | quote }}
@@ -101,8 +101,9 @@ data:
   {{- else }}
   STARHUB_SERVER_MODEL_DOWNLOAD_ENDPOINT: {{ $service.externalUrl | quote }}
   {{- end }}
-  {{- $registry := or $service.model.registry .Values.global.image.registry "docker.io" }}
+  {{- $registry := or $service.model.dockerRegBase .Values.global.image.registry "docker.io" }}
   STARHUB_SERVER_MODEL_DOCKER_REG_BASE: {{ $registry | quote }}
+  STARHUB_SERVER_MODEL_DEPLOY_STATUS_CHECK_INTERVAL: {{ $service.model.deployStatusCheckInterval | default 10 | quote }}
   STARHUB_SERVER_CLUSTER_ID: {{ $service.originClusterID | quote }}
 
   ## Runner Configuration for S3

--- a/charts/runner/templates/configmap.yaml
+++ b/charts/runner/templates/configmap.yaml
@@ -59,7 +59,7 @@ data:
 
   ## Runner Configuration for Root Domain
   {{- $endpoint := include "common.endpoint.public" . | trimPrefix "http://" | trimPrefix "https://" }}
-  STARHUB_SERVER_PUBLIC_ROOT_DOMAIN: {{ ternary $endpoint "" $service.usePublicDomain | quote }}
+  STARHUB_SERVER_PUBLIC_ROOT_DOMAIN: {{ ternary $endpoint "" $service.space.usePublicDomain | quote }}
   #### Maybe not used, Domain app.internal is only a Placeholder
   STARHUB_SERVER_INTERNAL_ROOT_DOMAIN: {{ printf "%s.app.internal" (include "namespace.spaces" .) | quote }}
 
@@ -74,7 +74,7 @@ data:
   ## Runner Configuration for space-runtime
   STARHUB_SERVER_RUNNER_PUBLIC_DOCKER_REG_BASE: {{ or .Values.global.image.registry "docker.io" | quote }}
   ## Runner Configuration for PyPI Source
-  STARHUB_SERVER_SPACE_PYPI_INDEX_URL: {{ $service.pipIndexUrl | quote }}
+  STARHUB_SERVER_SPACE_PYPI_INDEX_URL: {{ $service.space.pipIndexUrl | quote }}
   ## Runner Configuration for ImageBuilder
   STARHUB_SERVER_RUNNER_IMAGE_BUILDER_GIT_IMAGE: "{{ or .Values.global.image.registry "docker.io" }}/opencsghq/git:2.52.0"
   STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_IMAGE: "{{ or .Values.global.image.registry "docker.io" }}/opencsghq/kaniko-executor:v1.24.0"
@@ -84,10 +84,18 @@ data:
 
   ## Runner Configuration for Argo
   STARHUB_SERVER_ARGO_SERVICE_ACCOUNT: {{ printf "%s-argo-workflow-executor" .Release.Name | quote }}
-  {{- $typeLabel := $service.gpuModelLabel.typeLabel }}
-  {{- $capacityLabel := $service.gpuModelLabel.capacityLabel }}
+  {{- $typeLabel := $service.space.gpuModelLabel.typeLabel }}
+  {{- $capacityLabel := $service.space.gpuModelLabel.capacityLabel }}
   STARHUB_SERVER_GPU_MODEL_LABEL: '[{"type_label": {{ $typeLabel | quote }}, "capacity_label": {{ $capacityLabel | quote }}}]'
   STARHUB_SERVER_MODEL_DEPLOY_TIMEOUT_IN_MINUTES: {{ $service.model.deployTimeout | default 60 | quote }}
+  ## Runner Configuration for Space Timeouts
+  STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES: {{ $service.space.deployTimeoutInMin | default 30 | quote }}
+  STARHUB_SERVER_SPACE_BUILD_TIMEOUT_IN_MINUTES: {{ $service.space.buildTimeoutInMin | default 30 | quote }}
+  STARHUB_SERVER_SPACE_STATUS_CHECK_INTERVAL: {{ $service.space.statusCheckInterval | default 10 | quote }}
+  ## Runner Configuration for Space Readiness Probe
+  STARHUB_SERVER_READINESS_DELAY_SECONDS: {{ $service.space.readinessDelaySeconds | default 120 | quote }}
+  STARHUB_SERVER_READINESS_PERIOD_SECONDS: {{ $service.space.readinessPeriodSeconds | default 10 | quote }}
+  STARHUB_SERVER_READINESS_FAILURE_THRESHOLD: {{ $service.space.readinessFailureThreshold | default 3 | quote }}
   {{- if $isBuiltIn }}
   STARHUB_SERVER_MODEL_DOWNLOAD_ENDPOINT: {{ include "common.endpoint.csghub" . | quote }}
   {{- else }}

--- a/charts/runner/templates/configmap.yaml
+++ b/charts/runner/templates/configmap.yaml
@@ -54,8 +54,8 @@ data:
   ## Runner Configuration for Space
   STARHUB_SERVER_CLUSTER_SPACES_NAMESPACE: {{ include "namespace.spaces" . | quote }}
   STARHUB_SERVER_CLUSTER_RUNNER_NAMESPACE: {{ .Release.Namespace | quote }}
-  STARHUB_SERVER_RUNNER_WATCH_CONFIGMAP_INTERVAL_IN_SEC: {{ $service.interval | default 60 | quote }}
-  STARHUB_SERVER_CLUSTER_REGION: {{ $service.region | default "region-0" | quote }}
+  STARHUB_SERVER_RUNNER_WATCH_CONFIGMAP_INTERVAL_IN_SEC: {{ $service.runner.interval | default 60 | quote }}
+  STARHUB_SERVER_CLUSTER_REGION: {{ $service.runner.region | default "region-0" | quote }}
 
   ## Runner Configuration for Root Domain
   {{- $endpoint := include "common.endpoint.public" . | trimPrefix "http://" | trimPrefix "https://" }}
@@ -76,10 +76,14 @@ data:
   ## Runner Configuration for PyPI Source
   STARHUB_SERVER_SPACE_PYPI_INDEX_URL: {{ $service.space.pipIndexUrl | quote }}
   ## Runner Configuration for ImageBuilder
-  STARHUB_SERVER_RUNNER_IMAGE_BUILDER_GIT_IMAGE: "{{ or .Values.global.image.registry "docker.io" }}/opencsghq/git:2.52.0"
-  STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_IMAGE: "{{ or .Values.global.image.registry "docker.io" }}/opencsghq/kaniko-executor:v1.24.0"
+  {{- $defaultReg := or .Values.global.image.registry "docker.io" }}
+  {{- $gitImage := $service.runner.imageBuilderGitImage | default (printf "%s/opencsghq/git:2.52.0" $defaultReg) }}
+  {{- $kanikoImage := $service.runner.imageBuilderKanikoImage | default (printf "%s/opencsghq/kaniko-executor:v1.24.0" $defaultReg) }}
+  {{- $statusTTL := $service.runner.imageBuilderStatusTTL | default "300" }}
+  STARHUB_SERVER_RUNNER_IMAGE_BUILDER_GIT_IMAGE: {{ $gitImage | quote }}
+  STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_IMAGE: {{ $kanikoImage | quote }}
   STARHUB_SERVER_RUNNER_IMAGE_BUILDER_JOB_TTL: "300"
-  STARHUB_SERVER_RUNNER_IMAGE_BUILDER_STATUS_TTL: "300"
+  STARHUB_SERVER_RUNNER_IMAGE_BUILDER_STATUS_TTL: {{ $statusTTL | quote }}
   STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_ARGS: {{ include "runner.kaniko.args" (dict "ctx" . "service" $service) | quote }}
 
   ## Runner Configuration for Argo
@@ -105,6 +109,8 @@ data:
   STARHUB_SERVER_MODEL_DOCKER_REG_BASE: {{ $registry | quote }}
   STARHUB_SERVER_MODEL_DEPLOY_STATUS_CHECK_INTERVAL: {{ $service.model.deployStatusCheckInterval | default 10 | quote }}
   STARHUB_SERVER_CLUSTER_ID: {{ $service.originClusterID | quote }}
+  ## Runner Configuration for HeartBeat
+  STARHUB_SERVER_RUNNER_HEARTBEAT_INTERVAL_IN_SEC: {{ $service.runner.hearBeatIntervalInSec | default 120 | quote }}
 
   ## Runner Configuration for S3
   {{- $s3Config := $service.objectStore }}
@@ -137,8 +143,8 @@ data:
   {{- end }}
 
   ## Runner Configuration for network
-  {{- if $service.applicationEndpoint }}
-  STARHUB_SERVER_RUNNER_APPLICATION_ENDPOINT: {{ $service.applicationEndpoint | quote }}
+  {{- if $service.runner.applicationEndpoint }}
+  STARHUB_SERVER_RUNNER_APPLICATION_ENDPOINT: {{ $service.runner.applicationEndpoint | quote }}
   {{- else }}
   {{- $ingressType := $service.knative.serving.ingress | default "gateway-api" }}
   {{- if eq $ingressType "kourier" }}
@@ -157,10 +163,10 @@ data:
   {{- end }}
 
   ## Runner Configuration for LWS
-  STARHUB_SERVER_RUNNER_NETWORK_INTERFACE: {{ $service.networkInterface | quote }}
+  STARHUB_SERVER_RUNNER_NETWORK_INTERFACE: {{ $service.runner.networkInterface | quote }}
 
   ## Runner Configuration for Spaces
-  STARHUB_SERVER_RUNNER_STORAGE_CLASS: {{ $service.storageClassName | quote }}
+  STARHUB_SERVER_RUNNER_STORAGE_CLASS: {{ $service.runner.storageClassName | quote }}
 
   {{- if .Values.volcano.enabled }}
   ## Runner Configuration for Volcano

--- a/charts/runner/templates/gateway.yaml
+++ b/charts/runner/templates/gateway.yaml
@@ -79,6 +79,6 @@ spec:
                 operator: In
                 values:
                   - {{ .Release.Namespace }}
-                  - {{ .Values.runner.namespace | default "spaces" }}
+                  - {{ (.Values.runner | default dict).namespace | default "spaces" }}
                   - {{ include "namespace.knative" . }}
 {{- end }}

--- a/charts/runner/templates/gateway.yaml
+++ b/charts/runner/templates/gateway.yaml
@@ -79,6 +79,6 @@ spec:
                 operator: In
                 values:
                   - {{ .Release.Namespace }}
-                  - {{ .Values.namespace | default "spaces" }}
+                  - {{ .Values.runner.namespace | default "spaces" }}
                   - {{ include "namespace.knative" . }}
 {{- end }}

--- a/charts/runner/tests/configmap_test.yaml
+++ b/charts/runner/tests/configmap_test.yaml
@@ -73,19 +73,23 @@ set:
   namespace: spaces
   mergingNamespace: disable
 
-  usePublicDomain: true
-
-  pipIndexUrl: https://pypi.tuna.tsinghua.edu.cn/simple/
-
-  extraBuildArgs: []
-
   model:
     deployTimeout: 30
     registry: model.unittest.io
 
-  gpuModelLabel:
-    typeLabel: nvidia.com/gpu.product
-    capacityLabel: nvidia.com/gpu
+  space:
+    usePublicDomain: true
+    pipIndexUrl: https://pypi.tuna.tsinghua.edu.cn/simple/
+    deployTimeoutInMin: "30"
+    buildTimeoutInMin: "30"
+    gpuModelLabel:
+      typeLabel: nvidia.com/gpu.product
+      capacityLabel: nvidia.com/gpu
+    extraBuildArgs: []
+    readinessDelaySeconds: "120"
+    readinessPeriodSeconds: "10"
+    readinessFailureThreshold: "3"
+    statusCheckInterval: "10"
 
   applicationEndpoint: http://kourier-internal.knative-serving.svc.cluster.local
 

--- a/charts/runner/tests/configmap_test.yaml
+++ b/charts/runner/tests/configmap_test.yaml
@@ -58,7 +58,6 @@ set:
     tls: {}
   hubAPIToken: unittest-api-token-standalone
   originClusterID: unittest-cluster
-  region: es-west-1
 
   ## Runner Definition
   name: runner-unittest
@@ -68,10 +67,19 @@ set:
     port: 8082
     protocol: TCP
 
-  interval: 30
-
-  namespace: spaces
-  mergingNamespace: disable
+  runner:
+    region: es-west-1
+    interval: 30
+    namespace: spaces
+    mergingNamespace: disable
+    imageBuilderGitImage: ""
+    imageBuilderKanikoImage: ""
+    imageBuilderStatusTTL: "300"
+    imageBuilderKanikoArgs: []
+    hearBeatIntervalInSec: "120"
+    applicationEndpoint: http://kourier-internal.knative-serving.svc.cluster.local
+    networkInterface: eth0
+    storageClassName: local-path
 
   model:
     deployTimeoutInMin: "60"
@@ -87,17 +95,10 @@ set:
     gpuModelLabel:
       typeLabel: nvidia.com/gpu.product
       capacityLabel: nvidia.com/gpu
-    extraBuildArgs: []
     readinessDelaySeconds: "120"
     readinessPeriodSeconds: "10"
     readinessFailureThreshold: "3"
     statusCheckInterval: "10"
-
-  applicationEndpoint: http://kourier-internal.knative-serving.svc.cluster.local
-
-  networkInterface: eth0
-
-  storageClassName: local-path
 
   knative:
     serving:
@@ -258,6 +259,18 @@ tests:
       - equal:
           path: data.STARHUB_SERVER_CLUSTER_ID
           value: "unittest-cluster"
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_HEARTBEAT_INTERVAL_IN_SEC
+          value: "120"
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_GIT_IMAGE
+          value: "unittest.io/opencsghq/git:2.52.0"
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_IMAGE
+          value: "unittest.io/opencsghq/kaniko-executor:v1.24.0"
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_STATUS_TTL
+          value: "300"
       - equal:
           path: data.STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES
           value: "30"

--- a/charts/runner/tests/configmap_test.yaml
+++ b/charts/runner/tests/configmap_test.yaml
@@ -74,8 +74,10 @@ set:
   mergingNamespace: disable
 
   model:
-    deployTimeout: 30
-    registry: model.unittest.io
+    deployTimeoutInMin: "60"
+    downloadEndpoint: "https://hub.opencsg.com"
+    dockerRegBase: model.unittest.io
+    deployStatusCheckInterval: "10"
 
   space:
     usePublicDomain: true
@@ -243,13 +245,37 @@ tests:
           value: '[{"type_label": "nvidia.com/gpu.product", "capacity_label": "nvidia.com/gpu"}]'
       - equal:
           path: data.STARHUB_SERVER_MODEL_DEPLOY_TIMEOUT_IN_MINUTES
-          value: "30"
+          value: "60"
       - equal:
           path: data.STARHUB_SERVER_MODEL_DOWNLOAD_ENDPOINT
           value: "https://csghub.unittest.io"
       - equal:
           path: data.STARHUB_SERVER_MODEL_DOCKER_REG_BASE
           value: "model.unittest.io"
+      - equal:
+          path: data.STARHUB_SERVER_MODEL_DEPLOY_STATUS_CHECK_INTERVAL
+          value: "10"
+      - equal:
+          path: data.STARHUB_SERVER_CLUSTER_ID
+          value: "unittest-cluster"
+      - equal:
+          path: data.STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES
+          value: "30"
+      - equal:
+          path: data.STARHUB_SERVER_SPACE_BUILD_TIMEOUT_IN_MINUTES
+          value: "30"
+      - equal:
+          path: data.STARHUB_SERVER_SPACE_STATUS_CHECK_INTERVAL
+          value: "10"
+      - equal:
+          path: data.STARHUB_SERVER_READINESS_DELAY_SECONDS
+          value: "120"
+      - equal:
+          path: data.STARHUB_SERVER_READINESS_PERIOD_SECONDS
+          value: "10"
+      - equal:
+          path: data.STARHUB_SERVER_READINESS_FAILURE_THRESHOLD
+          value: "3"
       - equal:
           path: data.STARHUB_SERVER_CLUSTER_ID
           value: "unittest-cluster"

--- a/charts/runner/tests/rbac_test.yaml
+++ b/charts/runner/tests/rbac_test.yaml
@@ -8,7 +8,8 @@ release:
 tests:
   - it: should create multiple RBAC with global.namespace <> Release.Namespace
     set:
-      namespace: "spaces"
+      runner:
+        namespace: "spaces"
       rbac.create: true
     asserts:
       - hasDocuments:
@@ -28,7 +29,8 @@ tests:
 
   - it: should create multiple RBAC with global.namespace = Release.Namespace
     set:
-      namespace: "csghub"
+      runner:
+        namespace: "csghub"
       rbac.create: true
     asserts:
       - hasDocuments:

--- a/charts/runner/values.schema.json
+++ b/charts/runner/values.schema.json
@@ -138,31 +138,70 @@
         "protocol": { "type": "string" }
       }
     },
-    "region": { "type": "string", "description": "Region the runner belongs to" },
-    "interval": { "type": "integer", "description": "Communication interval with server (seconds)" },
-    "namespace": { "type": "string", "description": "Namespace for user-deployed workloads" },
-    "mergingNamespace": { "type": "string", "enum": ["multi", "single", "disable"], "description": "Namespace merging strategy" },
-    "usePublicDomain": { "type": "boolean", "description": "Use public domain for application access" },
-    "pipIndexUrl": { "type": "string", "description": "Custom pip repository URL" },
-    "extraBuildArgs": { "type": "array", "items": { "type": "string" }, "description": "Extra Kaniko build arguments" },
+    "runner": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "description": "Runner operation configuration",
+          "properties": {
+            "region": { "type": "string", "description": "Region the runner belongs to" },
+            "interval": { "type": "integer", "description": "Communication interval with server (seconds)" },
+            "namespace": { "type": "string", "description": "Namespace for user-deployed workloads" },
+            "mergingNamespace": { "type": "string", "enum": ["multi", "single", "disable"], "description": "Namespace merging strategy" },
+            "imageBuilderGitImage": { "type": "string", "description": "Override image builder Git image" },
+            "imageBuilderKanikoImage": { "type": "string", "description": "Override image builder Kaniko image" },
+            "imageBuilderStatusTTL": { "type": "string", "description": "TTL for kaniko build pod status" },
+            "imageBuilderKanikoArgs": { "type": "array", "items": { "type": "string" }, "description": "Extra Kaniko build arguments" },
+            "hearBeatIntervalInSec": { "type": "string", "description": "Runner heartbeat interval (seconds)" },
+            "applicationEndpoint": { "type": "string", "description": "Knative endpoint override (auto-detected if empty)" },
+            "networkInterface": { "type": "string", "description": "Host network interface for distributed inference" },
+            "storageClassName": { "type": "string", "description": "StorageClass for space persistent volumes" }
+          }
+        }
+      ]
+    },
     "model": {
-      "type": "object",
-      "description": "Model image configuration",
-      "properties": {
-        "deployTimeout": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "Timeout for model deployment operations (seconds)" },
-        "registry": { "type": "string", "description": "Custom image registry for model images" }
-      }
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "description": "Model image configuration",
+          "properties": {
+            "deployTimeoutInMin": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "Timeout for model deployment operations (minutes)" },
+            "downloadEndpoint": { "type": "string", "description": "Model download endpoint URL" },
+            "dockerRegBase": { "type": "string", "description": "Custom image registry for model images" },
+            "deployStatusCheckInterval": { "type": "string", "description": "Interval for checking model deploy status (seconds)" }
+          }
+        }
+      ]
     },
-    "gpuModelLabel": {
-      "type": "object",
-      "properties": {
-        "typeLabel": { "type": "string" },
-        "capacityLabel": { "type": "string" }
-      }
+    "space": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "description": "Space configuration",
+          "properties": {
+            "usePublicDomain": { "type": "boolean", "description": "Use public domain for application access" },
+            "pipIndexUrl": { "type": "string", "description": "Custom pip repository URL" },
+            "deployTimeoutInMin": { "type": "string", "description": "Timeout for space deployment operations (minutes)" },
+            "buildTimeoutInMin": { "type": "string", "description": "Timeout for space build operations (minutes)" },
+            "gpuModelLabel": {
+              "type": "object",
+              "properties": {
+                "typeLabel": { "type": "string" },
+                "capacityLabel": { "type": "string" }
+              }
+            },
+            "readinessDelaySeconds": { "type": "string", "description": "Initial delay before readiness probe starts" },
+            "readinessPeriodSeconds": { "type": "string", "description": "Interval between readiness probe checks" },
+            "readinessFailureThreshold": { "type": "string", "description": "Consecutive failures before pod is marked unready" },
+            "statusCheckInterval": { "type": "string", "description": "Interval for checking space deployment status (seconds)" }
+          }
+        }
+      ]
     },
-    "applicationEndpoint": { "type": "string", "description": "Knative endpoint override (auto-detected if empty)" },
-    "networkInterface": { "type": "string", "description": "Host network interface for distributed inference" },
-    "storageClassName": { "type": "string", "description": "StorageClass for space persistent volumes" },
     "knative": {
       "type": "object",
       "properties": {

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -116,8 +116,10 @@ namespace: "spaces"                    # Namespace for user-deployed workloads
 mergingNamespace: "disable"            # Namespace merging: multi, single, disable
 
 model:                                 # Model image configuration
-  deployTimeout: "60"                  # Timeout (in seconds) for model deployment operations
-  registry: ""                         # Custom image registry for model-related images (empty uses global registry)
+  deployTimeoutInMin: "60"                  # Timeout (in seconds) for model deployment operations
+  downloadEndpoint: "https://hub.opencsg.com"
+  dockerRegBase: ""                         # Custom image registry for model-related images (empty uses global registry)
+  deployStatusCheckInterval: "10"
 
 space:
   ## Networking configuration

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -115,20 +115,38 @@ interval: 60                           # Communication interval with server (sec
 namespace: "spaces"                    # Namespace for user-deployed workloads
 mergingNamespace: "disable"            # Namespace merging: multi, single, disable
 
-## Networking configuration
-usePublicDomain: true                  # Use public domain for application access
-
-## Package and image management
-pipIndexUrl: "https://pypi.tuna.tsinghua.edu.cn/simple/"  # Custom pip repository
-extraBuildArgs: []                     # Extra Kaniko build arguments
 model:                                 # Model image configuration
   deployTimeout: "60"                  # Timeout (in seconds) for model deployment operations
   registry: ""                         # Custom image registry for model-related images (empty uses global registry)
 
-## GPU resource configuration
-gpuModelLabel:
-  typeLabel: "nvidia.com/gpu.product"  # GPU type label
-  capacityLabel: "nvidia.com/gpu"      # GPU capacity label
+space:
+  ## Networking configuration
+  usePublicDomain: true                  # Use public domain for application access
+
+  ## Custom PyPI index URL for space builds (e.g., internal mirror for faster pip installs)
+  pipIndexUrl: "https://pypi.tuna.tsinghua.edu.cn/simple/"
+
+  ## Timeout (in minutes) for space deployment operations
+  deployTimeoutInMin: "30"
+
+  ## Timeout (in minutes) for space image build operations
+  buildTimeoutInMin: "30"
+
+  ## GPU resource configuration
+  gpuModelLabel:
+    typeLabel: "nvidia.com/gpu.product"  # Kubernetes node label for GPU product type
+    capacityLabel: "nvidia.com/gpu"      # Kubernetes node label for GPU capacity
+
+  ## Package and image management
+  extraBuildArgs: []                     # Extra Kaniko build arguments
+
+  ## Kubernetes readiness probe configuration for space pods (in seconds)
+  readinessDelaySeconds: "120"         # Initial delay before readiness probe starts
+  readinessPeriodSeconds: "10"         # Interval between readiness probe checks
+  readinessFailureThreshold: "3"       # Consecutive failures before pod is marked unready
+
+  ## Interval (in seconds) for checking space deployment status
+  statusCheckInterval: "10"
 
 ## Knative networking configuration
 ## e.g. http://<load balancer ip> or http://kourier-internal.kourier-system.svc.cluster.local

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -107,13 +107,33 @@ service:
   port: 8082                               # Service port
   protocol: "TCP"                          # Network protocol
 
-## Runner operation and communication
-region: "region-0"                     # Region the runner belongs to
-interval: 60                           # Communication interval with server (seconds)
+runner:
+  ## Runner operation and communication
+  region: "region-0"                     # Region the runner belongs to
+  interval: 60                           # Communication interval with server (seconds)
 
-## Namespace management
-namespace: "spaces"                    # Namespace for user-deployed workloads
-mergingNamespace: "disable"            # Namespace merging: multi, single, disable
+  ## Namespace management
+  namespace: "spaces"                    # Namespace for user-deployed workloads
+  mergingNamespace: "disable"            # Namespace merging: multi, single, disable
+
+  imageBuilderGitImage: ""
+  imageBuilderKanikoImage: ""
+  imageBuilderStatusTTL: "300"
+  imageBuilderKanikoArgs: []  # extraBuildArgs: []
+
+  hearBeatIntervalInSec: "120"
+
+  ## Knative networking configuration
+  ## e.g. http://<load balancer ip> or http://kourier-internal.kourier-system.svc.cluster.local
+  # applicationEndpoint: ""
+
+  ## Host network interface name used for intern communication during distributed (LWS) inference
+  ## e.g. eth0
+  # networkInterface: ""
+
+  ## Kubernetes StorageClass name for persistent volume provisioning for space
+  # Example values: "local-path", "gp2"
+  # storageClassName: ""
 
 model:                                 # Model image configuration
   deployTimeoutInMin: "60"                  # Timeout (in seconds) for model deployment operations
@@ -139,9 +159,6 @@ space:
     typeLabel: "nvidia.com/gpu.product"  # Kubernetes node label for GPU product type
     capacityLabel: "nvidia.com/gpu"      # Kubernetes node label for GPU capacity
 
-  ## Package and image management
-  extraBuildArgs: []                     # Extra Kaniko build arguments
-
   ## Kubernetes readiness probe configuration for space pods (in seconds)
   readinessDelaySeconds: "120"         # Initial delay before readiness probe starts
   readinessPeriodSeconds: "10"         # Interval between readiness probe checks
@@ -149,18 +166,6 @@ space:
 
   ## Interval (in seconds) for checking space deployment status
   statusCheckInterval: "10"
-
-## Knative networking configuration
-## e.g. http://<load balancer ip> or http://kourier-internal.kourier-system.svc.cluster.local
-# applicationEndpoint: ""
-
-## Host network interface name used for intern communication during distributed (LWS) inference
-## e.g. eth0
-# networkInterface: ""
-
-## Kubernetes StorageClass name for persistent volume provisioning for space
-# Example values: "local-path", "gp2"
-# storageClassName: ""
 
 ## Knative Serving configuration
 knative:

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -107,21 +107,22 @@ service:
   port: 8082                               # Service port
   protocol: "TCP"                          # Network protocol
 
+## Runner configuration
 runner:
   ## Runner operation and communication
-  region: "region-0"                     # Region the runner belongs to
-  interval: 60                           # Communication interval with server (seconds)
+  region: "region-0"                       # Region the runner belongs to
 
   ## Namespace management
-  namespace: "spaces"                    # Namespace for user-deployed workloads
-  mergingNamespace: "disable"            # Namespace merging: multi, single, disable
+  # namespace: "spaces"                      # Namespace for user-deployed workloads
+  mergingNamespace: "disable"              # Namespace merging: multi, single, disable
 
-  imageBuilderGitImage: ""
-  imageBuilderKanikoImage: ""
-  imageBuilderStatusTTL: "300"
-  imageBuilderKanikoArgs: []  # extraBuildArgs: []
+  # Image builder management
+  # imageBuilderGitImage: ""               # Override image builder Git image
+  # imageBuilderKanikoImage: ""            # Override image builder Kaniko image
+  # imageBuilderStatusTTL: "300"           # TTL for kaniko build pod status
+  # imageBuilderKanikoArgs: []             # Extra Kaniko build arguments
 
-  hearBeatIntervalInSec: "120"
+  # hearBeatIntervalInSec: "120"           # Runner heartbeat interval (seconds)
 
   ## Knative networking configuration
   ## e.g. http://<load balancer ip> or http://kourier-internal.kourier-system.svc.cluster.local
@@ -132,27 +133,29 @@ runner:
   # networkInterface: ""
 
   ## Kubernetes StorageClass name for persistent volume provisioning for space
-  # Example values: "local-path", "gp2"
+  ## Example values: "local-path", "gp2"
   # storageClassName: ""
 
-model:                                 # Model image configuration
-  deployTimeoutInMin: "60"                  # Timeout (in seconds) for model deployment operations
-  downloadEndpoint: "https://hub.opencsg.com"
-  dockerRegBase: ""                         # Custom image registry for model-related images (empty uses global registry)
-  deployStatusCheckInterval: "10"
+## Model deploy configuration
+model:
+  deployTimeoutInMin: "60"                  # Timeout (in minutes) for model deployment operations
+  # downloadEndpoint: "https://hub.opencsg.com"
+  # dockerRegBase: ""                       # Custom image registry for model-related images (empty uses global registry)
+  # deployStatusCheckInterval: "10"
 
+## Space deploy configuration
 space:
   ## Networking configuration
-  usePublicDomain: true                  # Use public domain for application access
+  usePublicDomain: true                        # Use public domain for application access
 
   ## Custom PyPI index URL for space builds (e.g., internal mirror for faster pip installs)
   pipIndexUrl: "https://pypi.tuna.tsinghua.edu.cn/simple/"
 
   ## Timeout (in minutes) for space deployment operations
-  deployTimeoutInMin: "30"
+  # deployTimeoutInMin: "30"
 
   ## Timeout (in minutes) for space image build operations
-  buildTimeoutInMin: "30"
+  # buildTimeoutInMin: "30"
 
   ## GPU resource configuration
   gpuModelLabel:
@@ -160,12 +163,12 @@ space:
     capacityLabel: "nvidia.com/gpu"      # Kubernetes node label for GPU capacity
 
   ## Kubernetes readiness probe configuration for space pods (in seconds)
-  readinessDelaySeconds: "120"         # Initial delay before readiness probe starts
-  readinessPeriodSeconds: "10"         # Interval between readiness probe checks
-  readinessFailureThreshold: "3"       # Consecutive failures before pod is marked unready
+  # readinessDelaySeconds: "120"              # Initial delay before readiness probe starts
+  # readinessPeriodSeconds: "10"              # Interval between readiness probe checks
+  # readinessFailureThreshold: "3"            # Consecutive failures before pod is marked unready
 
   ## Interval (in seconds) for checking space deployment status
-  statusCheckInterval: "10"
+  # statusCheckInterval: "10"
 
 ## Knative Serving configuration
 knative:


### PR DESCRIPTION
## Summary
- Restructured runner chart values with dedicated `space`, `model`, and `runner` subsections to align with server config struct
- Synced the runner value restructuring to the csghub chart (which depends on runner as a subchart)
- Added 4 missing environment variables to csghub configmap that the server needs
- Rebuilt csghub values.schema.json to match the new nested runner value structure
- All paths in httproutes, configmap templates updated for the new nesting

## Test plan
- [x] 121 csghub chart unit tests pass
- [x] 28 runner chart unit tests pass
- [x] ct lint passed on both charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)