### PR TITLE
fix: use integer type for numeric runner params

### DIFF
--- a/charts/csghub/values.schema.json
+++ b/charts/csghub/values.schema.json
@@ -198,10 +198,10 @@
         "model": {
           "type": "object",
           "properties": {
-            "deployTimeoutInMin": {"type": "string"},
+            "deployTimeoutInMin": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
             "downloadEndpoint": {"type": "string"},
             "dockerRegBase": {"type": "string"},
-            "deployStatusCheckInterval": {"type": "string"}
+            "deployStatusCheckInterval": {"oneOf": [{"type": "string"}, {"type": "integer"}]}
           },
           "additionalProperties": true
         },
@@ -210,13 +210,13 @@
           "properties": {
             "usePublicDomain": {"type": "boolean"},
             "pipIndexUrl": {"type": "string"},
-            "deployTimeoutInMin": {"type": "string"},
-            "buildTimeoutInMin": {"type": "string"},
+            "deployTimeoutInMin": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+            "buildTimeoutInMin": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
             "gpuModelLabel": {"type": "object", "additionalProperties": true},
-            "readinessDelaySeconds": {"type": "string"},
-            "readinessPeriodSeconds": {"type": "string"},
-            "readinessFailureThreshold": {"type": "string"},
-            "statusCheckInterval": {"type": "string"}
+            "readinessDelaySeconds": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+            "readinessPeriodSeconds": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+            "readinessFailureThreshold": {"oneOf": [{"type": "string"}, {"type": "integer"}]},
+            "statusCheckInterval": {"oneOf": [{"type": "string"}, {"type": "integer"}]}
           },
           "additionalProperties": true
         },

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -446,28 +446,28 @@ runner:
 
   ## Model deploy configuration
   model:
-    deployTimeoutInMin: "60"             # Timeout (in minutes) for model deployment operations
+    deployTimeoutInMin: 60             # Timeout (in minutes) for model deployment operations
     # downloadEndpoint: ""               # Model download endpoint URL
     # dockerRegBase: ""                  # Custom image registry for model images
-    # deployStatusCheckInterval: "10"    # Interval for checking model deploy status (seconds)
+    # deployStatusCheckInterval: 10    # Interval for checking model deploy status (seconds)
 
   ## Space deploy configuration
   space:
     usePublicDomain: true                # Use public domain for application access
     pipIndexUrl: "https://pypi.tuna.tsinghua.edu.cn/simple/"  # Custom pip repository
 
-    # deployTimeoutInMin: "30"           # Timeout (in minutes) for space deployment operations
-    # buildTimeoutInMin: "30"            # Timeout (in minutes) for space build operations
+    # deployTimeoutInMin: 30           # Timeout (in minutes) for space deployment operations
+    # buildTimeoutInMin: 30            # Timeout (in minutes) for space build operations
 
     ## GPU resource configuration
     gpuModelLabel:
       typeLabel: "nvidia.com/gpu.product"  # GPU type label
       capacityLabel: "nvidia.com/gpu"      # GPU capacity label
 
-    # readinessDelaySeconds: "120"       # Initial delay before readiness probe starts
-    # readinessPeriodSeconds: "10"       # Interval between readiness probe checks
-    # readinessFailureThreshold: "3"     # Consecutive failures before pod is marked unready
-    # statusCheckInterval: "10"          # Interval for checking space deployment status (seconds)
+    # readinessDelaySeconds: 120       # Initial delay before readiness probe starts
+    # readinessPeriodSeconds: 10       # Interval between readiness probe checks
+    # readinessFailureThreshold: 3     # Consecutive failures before pod is marked unready
+    # statusCheckInterval: 10          # Interval for checking space deployment status (seconds)
 
   ## Knative Serving configuration
   knative:

--- a/charts/runner/tests/configmap_test.yaml
+++ b/charts/runner/tests/configmap_test.yaml
@@ -74,31 +74,31 @@ set:
     mergingNamespace: disable
     imageBuilderGitImage: ""
     imageBuilderKanikoImage: ""
-    imageBuilderStatusTTL: "300"
+    imageBuilderStatusTTL: 300
     imageBuilderKanikoArgs: []
-    hearBeatIntervalInSec: "120"
+    hearBeatIntervalInSec: 120
     applicationEndpoint: http://kourier-internal.knative-serving.svc.cluster.local
     networkInterface: eth0
     storageClassName: local-path
 
   model:
-    deployTimeoutInMin: "60"
+    deployTimeoutInMin: 60
     downloadEndpoint: "https://hub.opencsg.com"
     dockerRegBase: model.unittest.io
-    deployStatusCheckInterval: "10"
+    deployStatusCheckInterval: 10
 
   space:
     usePublicDomain: true
     pipIndexUrl: https://pypi.tuna.tsinghua.edu.cn/simple/
-    deployTimeoutInMin: "30"
-    buildTimeoutInMin: "30"
+    deployTimeoutInMin: 30
+    buildTimeoutInMin: 30
     gpuModelLabel:
       typeLabel: nvidia.com/gpu.product
       capacityLabel: nvidia.com/gpu
-    readinessDelaySeconds: "120"
-    readinessPeriodSeconds: "10"
-    readinessFailureThreshold: "3"
-    statusCheckInterval: "10"
+    readinessDelaySeconds: 120
+    readinessPeriodSeconds: 10
+    readinessFailureThreshold: 3
+    statusCheckInterval: 10
 
   knative:
     serving:

--- a/charts/runner/values.schema.json
+++ b/charts/runner/values.schema.json
@@ -151,9 +151,9 @@
             "mergingNamespace": { "type": "string", "enum": ["multi", "single", "disable"], "description": "Namespace merging strategy" },
             "imageBuilderGitImage": { "type": "string", "description": "Override image builder Git image" },
             "imageBuilderKanikoImage": { "type": "string", "description": "Override image builder Kaniko image" },
-            "imageBuilderStatusTTL": { "type": "string", "description": "TTL for kaniko build pod status" },
+            "imageBuilderStatusTTL": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "TTL for kaniko build pod status" },
             "imageBuilderKanikoArgs": { "type": "array", "items": { "type": "string" }, "description": "Extra Kaniko build arguments" },
-            "hearBeatIntervalInSec": { "type": "string", "description": "Runner heartbeat interval (seconds)" },
+            "hearBeatIntervalInSec": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "Runner heartbeat interval (seconds)" },
             "applicationEndpoint": { "type": "string", "description": "Knative endpoint override (auto-detected if empty)" },
             "networkInterface": { "type": "string", "description": "Host network interface for distributed inference" },
             "storageClassName": { "type": "string", "description": "StorageClass for space persistent volumes" }
@@ -171,7 +171,7 @@
             "deployTimeoutInMin": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "Timeout for model deployment operations (minutes)" },
             "downloadEndpoint": { "type": "string", "description": "Model download endpoint URL" },
             "dockerRegBase": { "type": "string", "description": "Custom image registry for model images" },
-            "deployStatusCheckInterval": { "type": "string", "description": "Interval for checking model deploy status (seconds)" }
+            "deployStatusCheckInterval": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "Interval for checking model deploy status (seconds)" }
           }
         }
       ]
@@ -185,8 +185,8 @@
           "properties": {
             "usePublicDomain": { "type": "boolean", "description": "Use public domain for application access" },
             "pipIndexUrl": { "type": "string", "description": "Custom pip repository URL" },
-            "deployTimeoutInMin": { "type": "string", "description": "Timeout for space deployment operations (minutes)" },
-            "buildTimeoutInMin": { "type": "string", "description": "Timeout for space build operations (minutes)" },
+            "deployTimeoutInMin": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "Timeout for space deployment operations (minutes)" },
+            "buildTimeoutInMin": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "Timeout for space build operations (minutes)" },
             "gpuModelLabel": {
               "type": "object",
               "properties": {
@@ -194,10 +194,10 @@
                 "capacityLabel": { "type": "string" }
               }
             },
-            "readinessDelaySeconds": { "type": "string", "description": "Initial delay before readiness probe starts" },
-            "readinessPeriodSeconds": { "type": "string", "description": "Interval between readiness probe checks" },
-            "readinessFailureThreshold": { "type": "string", "description": "Consecutive failures before pod is marked unready" },
-            "statusCheckInterval": { "type": "string", "description": "Interval for checking space deployment status (seconds)" }
+            "readinessDelaySeconds": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "Initial delay before readiness probe starts" },
+            "readinessPeriodSeconds": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "Interval between readiness probe checks" },
+            "readinessFailureThreshold": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "Consecutive failures before pod is marked unready" },
+            "statusCheckInterval": { "oneOf": [{ "type": "string" }, { "type": "integer" }], "description": "Interval for checking space deployment status (seconds)" }
           }
         }
       ]

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -119,10 +119,10 @@ runner:
   # Image builder management
   # imageBuilderGitImage: ""               # Override image builder Git image
   # imageBuilderKanikoImage: ""            # Override image builder Kaniko image
-  # imageBuilderStatusTTL: "300"           # TTL for kaniko build pod status
+  # imageBuilderStatusTTL: 300           # TTL for kaniko build pod status
   # imageBuilderKanikoArgs: []             # Extra Kaniko build arguments
 
-  # hearBeatIntervalInSec: "120"           # Runner heartbeat interval (seconds)
+  # hearBeatIntervalInSec: 120           # Runner heartbeat interval (seconds)
 
   ## Knative networking configuration
   ## e.g. http://<load balancer ip> or http://kourier-internal.kourier-system.svc.cluster.local
@@ -138,10 +138,10 @@ runner:
 
 ## Model deploy configuration
 model:
-  deployTimeoutInMin: "60"                  # Timeout (in minutes) for model deployment operations
+  deployTimeoutInMin: 60                  # Timeout (in minutes) for model deployment operations
   # downloadEndpoint: "https://hub.opencsg.com"
   # dockerRegBase: ""                       # Custom image registry for model-related images (empty uses global registry)
-  # deployStatusCheckInterval: "10"
+  # deployStatusCheckInterval: 10
 
 ## Space deploy configuration
 space:
@@ -152,10 +152,10 @@ space:
   pipIndexUrl: "https://pypi.tuna.tsinghua.edu.cn/simple/"
 
   ## Timeout (in minutes) for space deployment operations
-  # deployTimeoutInMin: "30"
+  # deployTimeoutInMin: 30
 
   ## Timeout (in minutes) for space image build operations
-  # buildTimeoutInMin: "30"
+  # buildTimeoutInMin: 30
 
   ## GPU resource configuration
   gpuModelLabel:
@@ -163,12 +163,12 @@ space:
     capacityLabel: "nvidia.com/gpu"      # Kubernetes node label for GPU capacity
 
   ## Kubernetes readiness probe configuration for space pods (in seconds)
-  # readinessDelaySeconds: "120"              # Initial delay before readiness probe starts
-  # readinessPeriodSeconds: "10"              # Interval between readiness probe checks
-  # readinessFailureThreshold: "3"            # Consecutive failures before pod is marked unready
+  # readinessDelaySeconds: 120              # Initial delay before readiness probe starts
+  # readinessPeriodSeconds: 10              # Interval between readiness probe checks
+  # readinessFailureThreshold: 3            # Consecutive failures before pod is marked unready
 
   ## Interval (in seconds) for checking space deployment status
-  # statusCheckInterval: "10"
+  # statusCheckInterval: 10
 
 ## Knative Serving configuration
 knative:


### PR DESCRIPTION
## Summary
- Change numeric runner parameters from string to integer type in values.yaml (runner + csghub)
- Update values.schema.json to accept both string and integer (backward compatible)
- Update unit test fixtures to use integer type

## Test plan
- [x] helm unittest passes
- [x] ct lint passes (runner + csghub)
- [x] ConfigMap output unchanged (| quote converts int to string)

🤖 Generated with [Claude Code](https://claude.com/claude-code)