### PR TITLE
fix: dedup loki/prome gateway auth field

### DIFF
--- a/charts/csghub/templates/NOTES.txt
+++ b/charts/csghub/templates/NOTES.txt
@@ -82,7 +82,7 @@ Example:
 {{- end }}
 
 {{- $promeSvc := include "common.service" (dict "ctx" . "service" "prometheus") | fromYaml }}
-{{- if $promeSvc.gateway.enabled }}
+{{- if $promeSvc.gatewayAuth.enabled }}
 ---
 
 🔥 Prometheus Graph

--- a/charts/csghub/templates/csghub/configmap.yaml
+++ b/charts/csghub/templates/csghub/configmap.yaml
@@ -329,9 +329,6 @@ data:
   {{- $promeHost := include "common.names.custom" (list . "prometheus-server") }}
   {{- $promePort := dig "service" "port" 80 $promeSvc }}
   STARHUB_SERVER_PROMETHEUS_API_ADDRESS: {{ printf "http://%s:%v/api/v1/query" $promeHost $promePort | quote }}
-  {{- with $promeSvc.gateway.basicAuth }}
-  STARHUB_SERVER_PROMETHEUS_BASIC_AUTH: {{ printf "%s:%s" .username .password | b64enc | quote }}
-  {{- end }}
   {{- end }}
 
   ## Server Configuration for Loki

--- a/charts/csghub/templates/loki/httproutes.yaml
+++ b/charts/csghub/templates/loki/httproutes.yaml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $service := include "common.service" (dict "ctx" . "service" "loki") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
-{{- if $service.gateway.enabled }}
+{{- if $service.gatewayAuth.enabled }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/csghub/templates/loki/secret.yaml
+++ b/charts/csghub/templates/loki/secret.yaml
@@ -4,8 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */ -}}
 
 {{- $service := include "common.service" (dict "ctx" . "service" "loki") | fromYaml }}
-{{- $gatewayConfig := include "common.gateway.config" (dict "ctx" . "service" $service) | fromYaml }}
-{{- if and $gatewayConfig.enabled $service.gateway.basicAuth }}
+{{- if $service.gatewayAuth.htpasswd }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
 apiVersion: v1
 kind: Secret
@@ -17,6 +16,6 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- $defaultHtpasswd := $service.gateway.basicAuth.htpasswd }}
-  .htpasswd: {{ $defaultHtpasswd | required "loki.gateway.basicAuth.htpasswd is required" | b64enc | quote }}
+  {{- $defaultHtpasswd := $service.gatewayAuth.htpasswd }}
+  .htpasswd: {{ $defaultHtpasswd | required "loki.gatewayAuth.htpasswd is required" | b64enc | quote }}
 {{- end }}

--- a/charts/csghub/templates/loki/securitypolicy.yaml
+++ b/charts/csghub/templates/loki/securitypolicy.yaml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $service := include "common.service" (dict "ctx" . "service" "loki") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
-{{- if and $service.gateway.enabled (regexMatch "envoyproxy" .Values.global.gateway.controllerName) }}
+{{- if and $service.gatewayAuth.enabled (regexMatch "envoyproxy" .Values.global.gateway.controllerName) }}
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:

--- a/charts/csghub/templates/prometheus/httproutes.yaml
+++ b/charts/csghub/templates/prometheus/httproutes.yaml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $service := include "common.service" (dict "ctx" . "service" "prometheus") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
-{{- if $service.gateway.enabled }}
+{{- if $service.gatewayAuth.enabled }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:

--- a/charts/csghub/templates/prometheus/secret.yaml
+++ b/charts/csghub/templates/prometheus/secret.yaml
@@ -4,8 +4,7 @@ SPDX-License-Identifier: APACHE-2.0
 */ -}}
 
 {{- $service := include "common.service" (dict "ctx" . "service" "prometheus") | fromYaml }}
-{{- $gatewayConfig := include "common.gateway.config" (dict "ctx" . "service" $service) | fromYaml }}
-{{- if and $gatewayConfig.enabled $service.gateway.basicAuth }}
+{{- if $service.gatewayAuth.htpasswd }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
 apiVersion: v1
 kind: Secret
@@ -17,6 +16,6 @@ metadata:
     {{- include "common.labels" . | nindent 4 }}
 type: Opaque
 data:
-  {{- $defaultHtpasswd := $service.gateway.basicAuth.htpasswd }}
-  .htpasswd: {{ $defaultHtpasswd | required "prometheus.gateway.basicAuth.htpasswd is required" | b64enc | quote }}
+  {{- $defaultHtpasswd := $service.gatewayAuth.htpasswd }}
+  .htpasswd: {{ $defaultHtpasswd | required "prometheus.gatewayAuth.htpasswd is required" | b64enc | quote }}
 {{- end }}

--- a/charts/csghub/templates/prometheus/securitypolicy.yaml
+++ b/charts/csghub/templates/prometheus/securitypolicy.yaml
@@ -5,7 +5,7 @@ SPDX-License-Identifier: APACHE-2.0
 
 {{- $service := include "common.service" (dict "ctx" . "service" "prometheus") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
-{{- if and $service.gateway.enabled (regexMatch "envoyproxy" .Values.global.gateway.controllerName) }}
+{{- if and $service.gatewayAuth.enabled (regexMatch "envoyproxy" .Values.global.gateway.controllerName) }}
 apiVersion: gateway.envoyproxy.io/v1alpha1
 kind: SecurityPolicy
 metadata:

--- a/charts/csghub/templates/xnet/configmap.yaml
+++ b/charts/csghub/templates/xnet/configmap.yaml
@@ -67,9 +67,6 @@ data:
   {{- $promeHost := include "common.names.custom" (list . "prometheus-server") }}
   {{- $promePort := dig "service" "port" 80 $promeSvc }}
   STARHUB_SERVER_PROMETHEUS_API_ADDRESS: {{ printf "http://%s:%v/api/v1/query" $promeHost $promePort | quote }}
-  {{- with $promeSvc.gateway.basicAuth }}
-  STARHUB_SERVER_PROMETHEUS_BASIC_AUTH: {{ printf "%s:%s" .username .password | b64enc | quote }}
-  {{- end }}
   {{- end }}
 
   ## XNet configuration for Tracing logging

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -851,11 +851,12 @@ reloader:
 
 ## Loki log aggregation configuration
 loki:
+  gatewayAuth:
+    enabled: false                         # Enable Gateway BasicAuth for Loki
+    # htpasswd: ""                         # Generate with: htpasswd -nbs <username> <password>
+
   gateway:
-    enabled: false                         # Enable Loki gateway
-    basicAuth: {}                          # Basic authentication
-      ## Pre-computed htpasswd entry, generate with: htpasswd -nbs <username> <password>
-      # htpasswd: ""
+    enabled: false                         # Disable loki internal gateway default
 
   memcachedExporter:
     enabled: false                         # Disable memcached exporter
@@ -940,11 +941,9 @@ tempo:
 prometheus:
   enabled: true                            # Enable Prometheus
 
-  gateway:
-    enabled: false                         # Enable Prometheus gateway
-    basicAuth: {}                          # Basic authentication
-      ## Pre-computed htpasswd entry, generate with: htpasswd -nbs <username> <password>
-      # htpasswd: ""
+  gatewayAuth:
+    enabled: false                         # Enable Gateway BasicAuth for Prometheus
+    # htpasswd: ""                         # Generate with: htpasswd -nbs <username> <password>
 
 ## MemMachine configuration
 memmachine:


### PR DESCRIPTION
## Summary

Replace conflicting `.gateway.enabled` / `.gateway.basicAuth` with dedicated `.gatewayAuth` field for loki and prometheus services, avoiding field conflicts with subchart values. Use pre-computed `{SHA}` htpasswd to satisfy Envoy Gateway SecurityPolicy requirements.

## Changes

| File | Change |
|------|--------|
| `charts/csghub/templates/loki/httproutes.yaml` | `gateway.enabled` → `gatewayAuth.enabled` |
| `charts/csghub/templates/loki/secret.yaml` | `gateway.basicAuth.htpasswd` → `gatewayAuth.htpasswd` |
| `charts/csghub/templates/loki/securitypolicy.yaml` | `gateway.enabled` → `gatewayAuth.enabled` |
| `charts/csghub/templates/prometheus/httproutes.yaml` | `gateway.enabled` → `gatewayAuth.enabled` |
| `charts/csghub/templates/prometheus/secret.yaml` | `gateway.basicAuth.htpasswd` → `gatewayAuth.htpasswd` |
| `charts/csghub/templates/prometheus/securitypolicy.yaml` | `gateway.enabled` → `gatewayAuth.enabled` |
| `charts/csghub/templates/csghub/configmap.yaml` | Remove `STARHUB_SERVER_PROMETHEUS_BASIC_AUTH` |
| `charts/csghub/templates/xnet/configmap.yaml` | Remove `STARHUB_SERVER_PROMETHEUS_BASIC_AUTH` |
| `charts/csghub/templates/NOTES.txt` | `gateway.enabled` → `gatewayAuth.enabled` |
| `charts/csghub/values.yaml` | Remove `gateway.basicAuth`, add `gatewayAuth` |

## Test plan

- [x] `helm unittest` — all 121 csghub tests passed
- [x] `helm template` — verified correct rendering
- [x] `ct lint` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)