### PR TITLE
feat: split knative local and external gw

### DIFF
--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -25,7 +25,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.3
+version: 2.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/runner/templates/envoy-proxy.yaml
+++ b/charts/runner/templates/envoy-proxy.yaml
@@ -90,3 +90,28 @@ spec:
         {{- end }}
     {{- end }}
 {{- end }}
+
+{{- /* EnvoyProxy for knative-local gateways (always ClusterIP since local gateways handle only internal traffic) */}}
+{{- if and $isEnvoyProxy (eq $ingressType "gateway-api") }}
+{{- $knativeLocalName := include "common.names.custom" (list . "envoy-proxy-knative-local") }}
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: EnvoyProxy
+metadata:
+  name: {{ $knativeLocalName }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  provider:
+    type: Kubernetes
+    kubernetes:
+    {{- if $isOpencsg }}
+      envoyDeployment:
+        container:
+          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.36.4
+    {{- else }}
+      envoyDeployment: {}
+    {{- end }}
+      envoyService:
+        name: {{ include "common.names.custom" (list . "envoy-knative-local") }}
+        type: ClusterIP
+{{- end }}

--- a/charts/runner/templates/gateway.yaml
+++ b/charts/runner/templates/gateway.yaml
@@ -81,4 +81,34 @@ spec:
                   - {{ .Release.Namespace }}
                   - {{ (.Values.runner | default dict).namespace | default "spaces" }}
                   - {{ include "namespace.knative" . }}
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: knative-local
+  namespace: {{ .Release.Namespace }}
+spec:
+  gatewayClassName: csghub-gateway
+  {{- if regexMatch "envoyproxy" .Values.global.gateway.controllerName }}
+  infrastructure:
+    parametersRef:
+      group: gateway.envoyproxy.io
+      kind: EnvoyProxy
+      name: {{ include "common.names.custom" (list . "envoy-proxy-knative-local") }}
+  {{- end }}
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: 80
+      allowedRoutes:
+        namespaces:
+          from: Selector
+          selector:
+            matchExpressions:
+              - key: kubernetes.io/metadata.name
+                operator: In
+                values:
+                  - {{ .Release.Namespace }}
+                  - {{ (.Values.runner | default dict).namespace | default "spaces" }}
+                  - {{ include "namespace.knative" . }}
 {{- end }}

--- a/charts/runner/templates/knativeserving.yaml
+++ b/charts/runner/templates/knativeserving.yaml
@@ -106,7 +106,7 @@ spec:
           - HTTPRouteRequestTimeout
       local-gateways: |
         - class: eg-internal
-          gateway: {{ .Release.Namespace }}/knative
+          gateway: {{ .Release.Namespace }}/knative-local
           supported-features:
           - HTTPRouteRequestTimeout
     {{- end }}

--- a/charts/runner/tests/gateway_test.yaml
+++ b/charts/runner/tests/gateway_test.yaml
@@ -216,8 +216,9 @@ tests:
           path: spec.listeners[0].allowedRoutes.namespaces.selector.matchExpressions[0].values
           content: knative-serving
 
-  - it: Should render knative-gateway in gateway-api + builtIn mode
+  - it: Should render knative gateway in gateway-api + builtIn mode
     template: gateway.yaml
+    documentIndex: 0
     set:
       global:
         chartContext:
@@ -227,7 +228,26 @@ tests:
           ingress: gateway-api
     asserts:
       - hasDocuments:
-          count: 1
+          count: 2
+      - isKind:
+          of: Gateway
       - equal:
           path: metadata.name
           value: knative
+
+  - it: Should render knative-local gateway in gateway-api + builtIn mode
+    template: gateway.yaml
+    documentIndex: 1
+    set:
+      global:
+        chartContext:
+          isBuiltIn: true
+      knative:
+        serving:
+          ingress: gateway-api
+    asserts:
+      - isKind:
+          of: Gateway
+      - equal:
+          path: metadata.name
+          value: knative-local

--- a/charts/runner/tests/knativeserving_test.yaml
+++ b/charts/runner/tests/knativeserving_test.yaml
@@ -310,6 +310,6 @@ tests:
           path: spec.config["gateway"]["local-gateways"]
           value: |
             - class: eg-internal
-              gateway: csghub/knative
+              gateway: csghub/knative-local
               supported-features:
               - HTTPRouteRequestTimeout


### PR DESCRIPTION
## Summary

Split the Knative serving local-gateways and external-gateways into two independent Gateway resources. Previously both pointed to the same `knative` Gateway, which made it impossible to route external and internal traffic differently.

## Changes

- **`charts/runner/templates/gateway.yaml`** — Add a new `knative-local` Gateway resource for cluster-internal traffic
- **`charts/runner/templates/envoy-proxy.yaml`** — Add a corresponding `envoy-proxy-knative-local` EnvoyProxy with `ClusterIP` service type (no external exposure)
- **`charts/runner/templates/knativeserving.yaml`** — Update `local-gateways` to reference `knative-local` instead of `knative`
- **`charts/runner/tests/gateway_test.yaml`** — Add test coverage for the new knative-local Gateway
- **`charts/runner/tests/knativeserving_test.yaml`** — Update expected local-gateways value
- **`charts/runner/Chart.yaml`** — Bump chart version to 2.2.4

## Test plan

- [x] `helm unittest charts/runner` — 30 tests passed
- [x] `helm template` — all charts rendered correctly
- [x] YAML validation — all charts passed

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>