### PR TITLE
Expose runner envoy proxy metrics

### DIFF
--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.23.3
 - name: prometheus
   repository: https://charts.opencsg.com/infra
-  version: 28.6.0
+  version: 29.14.0
 - name: runner
   repository: https://charts.opencsg.com/csghub
   version: 2.2.4
@@ -32,5 +32,5 @@ dependencies:
 - name: agentichub
   repository: https://charts.opencsg.com/csghub
   version: 0.6.2
-digest: sha256:4772f9ed243d2c289741c939564c31dbb84259b3dc3beceb152d4a7f12dda7b7
-generated: "2026-07-07T11:26:23.468448+08:00"
+digest: sha256:d981a563f8cbf27a57fc71e0bad42deded5e58277a89d67b5791a2d0d7b16131
+generated: "2026-07-09T11:19:31.20937+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -48,7 +48,7 @@ dependencies:
     repository: https://charts.opencsg.com/infra
     condition: tempo.enabled
   - name: prometheus
-    version: 28.6.0
+    version: 29.14.0
     repository: https://charts.opencsg.com/infra
     condition: prometheus.enabled
   - name: runner

--- a/charts/csghub/templates/envoy-proxy-metrics.yaml
+++ b/charts/csghub/templates/envoy-proxy-metrics.yaml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Service
 metadata:
-  name: envoy-proxy-metrics
+  name: envoy-proxy-listeners-metrics
   namespace: {{ .Release.Namespace }}
   annotations:
     prometheus.io/scrape: 'true'

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -945,61 +945,6 @@ prometheus:
     enabled: false                         # Enable Gateway BasicAuth for Prometheus
     # htpasswd: ""                         # Generate with: htpasswd -nbs <username> <password>
 
-  ## Extra scrape configs for Envoy Gateway / Envoy Proxy metrics
-  ## Scrapes envoy-proxy-*-metrics services exposed by envoy-proxy-metrics.yaml
-  ## templates in csghub and runner charts. Each Service targets one Gateway's
-  ## envoy pods (listeners / knative) via /stats/prometheus on port 19001.
-  extraScrapeConfigs: |
-    - job_name: knative-queue-proxy
-      scrape_interval: 30s
-      scrape_timeout: 10s
-      metrics_path: /metrics
-      kubernetes_sd_configs:
-        - role: endpoints
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace]
-          regex: spaces?(-(stg|stage))?
-          action: keep
-        - source_labels: [__meta_kubernetes_service_label_networking_internal_knative_dev_serviceType]
-          regex: Private
-          action: keep
-        - source_labels: [__meta_kubernetes_endpoint_port_name]
-          regex: http-usermetric
-          action: keep
-        - source_labels: [__meta_kubernetes_pod_node_name]
-          target_label: kubernetes_node
-        - source_labels: [__meta_kubernetes_namespace]
-          target_label: namespace
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_name]
-          target_label: pod
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_name]
-          target_label: pod_name
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_container_name]
-          target_label: container
-          action: replace
-    - job_name: envoy-proxy
-      scrape_interval: 30s
-      scrape_timeout: 10s
-      metrics_path: /stats/prometheus
-      kubernetes_sd_configs:
-        - role: endpoints
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_service_name]
-          regex: envoy-proxy-.*-metrics
-          action: keep
-        - source_labels: [__meta_kubernetes_namespace]
-          target_label: namespace
-          action: replace
-        - source_labels: [__meta_kubernetes_service_name]
-          target_label: service
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_node_name]
-          target_label: node
-          action: replace
-
 ## MemMachine configuration
 memmachine:
   enabled: false

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -945,6 +945,61 @@ prometheus:
     enabled: false                         # Enable Gateway BasicAuth for Prometheus
     # htpasswd: ""                         # Generate with: htpasswd -nbs <username> <password>
 
+  ## Extra scrape configs for Envoy Gateway / Envoy Proxy metrics
+  ## Scrapes envoy-proxy-*-metrics services exposed by envoy-proxy-metrics.yaml
+  ## templates in csghub and runner charts. Each Service targets one Gateway's
+  ## envoy pods (listeners / knative) via /stats/prometheus on port 19001.
+  extraScrapeConfigs: |
+    - job_name: knative-queue-proxy
+      scrape_interval: 30s
+      scrape_timeout: 10s
+      metrics_path: /metrics
+      kubernetes_sd_configs:
+        - role: endpoints
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_namespace]
+          regex: spaces?(-(stg|stage))?
+          action: keep
+        - source_labels: [__meta_kubernetes_service_label_networking_internal_knative_dev_serviceType]
+          regex: Private
+          action: keep
+        - source_labels: [__meta_kubernetes_endpoint_port_name]
+          regex: http-usermetric
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          target_label: kubernetes_node
+        - source_labels: [__meta_kubernetes_namespace]
+          target_label: namespace
+          action: replace
+        - source_labels: [__meta_kubernetes_pod_name]
+          target_label: pod
+          action: replace
+        - source_labels: [__meta_kubernetes_pod_name]
+          target_label: pod_name
+          action: replace
+        - source_labels: [__meta_kubernetes_pod_container_name]
+          target_label: container
+          action: replace
+    - job_name: envoy-proxy
+      scrape_interval: 30s
+      scrape_timeout: 10s
+      metrics_path: /stats/prometheus
+      kubernetes_sd_configs:
+        - role: endpoints
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: envoy-proxy-.*-metrics
+          action: keep
+        - source_labels: [__meta_kubernetes_namespace]
+          target_label: namespace
+          action: replace
+        - source_labels: [__meta_kubernetes_service_name]
+          target_label: service
+          action: replace
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          target_label: node
+          action: replace
+
 ## MemMachine configuration
 memmachine:
   enabled: false

--- a/charts/runner/templates/envoy-proxy-metrics.yaml
+++ b/charts/runner/templates/envoy-proxy-metrics.yaml
@@ -1,0 +1,63 @@
+{{- /*
+Copyright OpenCSG, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/ -}}
+
+{{- $gateway := .Values.global.gateway }}
+{{- $isEnvoyProxy := regexMatch "envoyproxy" $gateway.controllerName }}
+{{- $service := include "common.service" . | fromYaml }}
+{{- $ingressType := $service.knative.serving.ingress | default "gateway-api" }}
+{{- $gatewayAPI := eq $ingressType "gateway-api" }}
+
+{{- /* Metrics Service for the main listeners Gateway (standalone mode only) */}}
+{{- if and $isEnvoyProxy (not .Values.global.chartContext.isBuiltIn) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy-proxy-listeners-metrics
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '19001'
+    prometheus.io/path: '/stats/prometheus'
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/managed-by: envoy-gateway
+    app.kubernetes.io/name: envoy
+    gateway.envoyproxy.io/owning-gateway-name: listeners
+    gateway.envoyproxy.io/owning-gateway-namespace: {{ .Release.Namespace }}
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 19001
+      targetPort: 19001
+{{- end }}
+
+{{- /* Metrics Service for the knative external Gateway (gateway-api mode only) */}}
+{{- if and $isEnvoyProxy $gatewayAPI }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy-proxy-knative-metrics
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '19001'
+    prometheus.io/path: '/stats/prometheus'
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/managed-by: envoy-gateway
+    app.kubernetes.io/name: envoy
+    gateway.envoyproxy.io/owning-gateway-name: knative
+    gateway.envoyproxy.io/owning-gateway-namespace: {{ .Release.Namespace }}
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 19001
+      targetPort: 19001
+{{- end }}


### PR DESCRIPTION
## Summary

Expose Envoy Proxy metrics for Prometheus to scrape. Previously, the single `envoy-proxy-metrics` Service used a selector that only matched the `listeners` Gateway's envoy pods, and a Service with multiple backend endpoints returns a random one per request — so Prometheus only ever scraped one envoy pod, missing the others (knative external gateway, etc.).

This PR splits metrics exposure into per-Gateway Services, each with a selector pinned to one Gateway's envoy pods, and updates the Prometheus scrape config to discover all of them via a regex.

## Changes

- **`charts/csghub/templates/envoy-proxy-metrics.yaml`** — Rename Service from `envoy-proxy-metrics` to `envoy-proxy-listeners-metrics` so the name reflects which Gateway it scrapes
- **`charts/runner/templates/envoy-proxy-metrics.yaml`** (new) — Add two metrics Services for the runner chart:
  - `envoy-proxy-listeners-metrics` — for the standalone `listeners` Gateway (only in standalone mode)
  - `envoy-proxy-knative-metrics` — for the `knative` external Gateway (gateway-api mode only)
  - Each Service pins its selector to one `gateway.envoyproxy.io/owning-gateway-name` so there's exactly one backend endpoint per Service
- **`charts/csghub/values.yaml`** — Add `prometheus.extraScrapeConfigs` that discovers all `envoy-proxy-.*-metrics` Services via `kubernetes_sd_configs` (role: endpoints) and scrapes `/stats/prometheus` on port 19001

## Why not knative-local?

The `knative-local` Gateway is ClusterIP-only and handles internal cluster traffic. Its metrics have low operational value, so no metrics Service is created for it.

## Test plan

- [x] `helm unittest charts/runner charts/csghub` — 151 tests passed
- [x] `helm template` — all metrics Services render correctly with proper selectors
- [x] Verified scrape config picks up `envoy-proxy-.*-metrics` regex across both charts

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>