### PR TITLE
feat: update runner to v2.3.0

### DIFF
--- a/charts/runner/Chart.lock
+++ b/charts/runner/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 2.2.7
 - name: prometheus
   repository: https://charts.opencsg.com/infra
-  version: 28.6.0
+  version: 29.14.0
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
   version: 1.6.7
@@ -26,5 +26,5 @@ dependencies:
 - name: agent-sandbox
   repository: https://charts.opencsg.com/csghub
   version: 0.2.1
-digest: sha256:de190ff3f024d23afdaf798309d47f1048d3f3c1e57e4db272453beb64aaa4ce
-generated: "2026-06-16T16:20:30.640531+08:00"
+digest: sha256:76005cec5be1772dceac2eb8137db6b4549227cd66bdd4a381e143c47f6d6d68
+generated: "2026-07-09T12:32:56.902445+08:00"

--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -25,13 +25,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.4
+version: 2.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: v2.2.1
+appVersion: v2.3.0
 
 # Defined dependencies for subChart
 dependencies:
@@ -46,7 +46,7 @@ dependencies:
       - dependencies
       - reloader
   - name: prometheus
-    version: 28.6.0
+    version: 29.14.0
     repository: https://charts.opencsg.com/infra
     condition: prometheus.enabled
     tags:

--- a/charts/runner/templates/envoy-proxy-metrics.yaml
+++ b/charts/runner/templates/envoy-proxy-metrics.yaml
@@ -1,0 +1,63 @@
+{{- /*
+Copyright OpenCSG, Inc. All Rights Reserved.
+SPDX-License-Identifier: APACHE-2.0
+*/ -}}
+
+{{- $gateway := .Values.global.gateway }}
+{{- $isEnvoyProxy := regexMatch "envoyproxy" $gateway.controllerName }}
+{{- $service := include "common.service" . | fromYaml }}
+{{- $ingressType := $service.knative.serving.ingress | default "gateway-api" }}
+{{- $gatewayAPI := eq $ingressType "gateway-api" }}
+
+{{- /* Metrics Service for the main listeners Gateway (standalone mode only) */}}
+{{- if and $isEnvoyProxy (not .Values.global.chartContext.isBuiltIn) }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy-proxy-listeners-metrics
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '19001'
+    prometheus.io/path: '/stats/prometheus'
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/managed-by: envoy-gateway
+    app.kubernetes.io/name: envoy
+    gateway.envoyproxy.io/owning-gateway-name: listeners
+    gateway.envoyproxy.io/owning-gateway-namespace: {{ .Release.Namespace }}
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 19001
+      targetPort: 19001
+{{- end }}
+
+{{- /* Metrics Service for the knative external Gateway (gateway-api mode only) */}}
+{{- if and $isEnvoyProxy $gatewayAPI }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy-proxy-knative-metrics
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    prometheus.io/scrape: 'true'
+    prometheus.io/port: '19001'
+    prometheus.io/path: '/stats/prometheus'
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/component: proxy
+    app.kubernetes.io/managed-by: envoy-gateway
+    app.kubernetes.io/name: envoy
+    gateway.envoyproxy.io/owning-gateway-name: knative
+    gateway.envoyproxy.io/owning-gateway-namespace: {{ .Release.Namespace }}
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 19001
+      targetPort: 19001
+{{- end }}

--- a/charts/runner/templates/knativeserving.yaml
+++ b/charts/runner/templates/knativeserving.yaml
@@ -135,3 +135,7 @@ spec:
       {{- if $isOpencsgRegistry }}
       queue-sidecar-image: {{ $knativeRegistry }}/serving/cmd/queue:{{ $knativeVersion }}
       {{- end }}
+    observability:
+      metrics-protocol: "prometheus"
+      request-metrics-protocol: "prometheus"
+      request-metrics-endpoint: ":9091"

--- a/charts/runner/values.yaml
+++ b/charts/runner/values.yaml
@@ -48,7 +48,7 @@ global:
   image:
     registry: "docker.io"           # Image global registry, opencsg-registry.cn-beijing.cr.aliyuncs.com for mainland
     registryPolicy: "default"       # default or force, force will overwrite all others registries
-    tag: "v2.2.1"                   # Image tag format: {{version}}-{{edition}}
+    tag: "v2.3.0"                   # Image tag format: {{version}}-{{edition}}
     pullPolicy: "IfNotPresent"      # Image pull policy: Always, IfNotPresent, Never
     pullSecrets: []                 # Private registry authentication secrets
 
@@ -74,7 +74,7 @@ externalUrl: "https://csghub.example.com"
 image:
   # registry: "docker.io"                    # Docker registry
   repository: "opencsghq/csghub-server"
-  tag: "v2.2.1"                            # Image version tag
+  tag: "v2.3.0"                            # Image version tag
   pullPolicy: "IfNotPresent"               # Image pull policy: Always, IfNotPresent, Never
   pullSecrets: []                          # Docker registry secrets
 


### PR DESCRIPTION
## Summary

Bump runner chart to v2.3.0 and upgrade the bundled Prometheus subchart from 28.6.0 to 29.14.0. Also enable Knative serving observability so queue-proxy exposes request metrics in Prometheus format.

## Changes

- **`charts/runner/Chart.yaml`** — Bump chart version to 2.3.0 and appVersion to v2.3.0; bump `prometheus` dependency from 28.6.0 to 29.14.0
- **`charts/runner/Chart.lock`** — Sync lock file with the new prometheus dependency version
- **`charts/runner/templates/knativeserving.yaml`** — Add `observability` config to the KnativeServing spec:
  - `metrics-protocol: prometheus`
  - `request-metrics-protocol: prometheus`
  - `request-metrics-endpoint: :9091`
  
  This makes queue-proxy expose `revision_request_count` and other request metrics in Prometheus format on port 9091, so the existing `knative-queue-proxy` scrape job can collect them.
- **`charts/runner/values.yaml`** — Bump image tags from v2.2.1 to v2.3.0

## Why

Without the `observability` config, Knative queue-proxy defaults to the opencensus protocol and does not expose `revision_request_count` / `revision_request_total` / `kna_revisions` metrics in a format Prometheus can scrape. Setting `request-metrics-protocol: prometheus` and `request-metrics-endpoint: :9091` switches queue-proxy to Prometheus exposition on port 9091.

## Test plan

- [x] `helm unittest charts/runner` passes
- [x] `helm template` renders the KnativeServing CR with the new observability block
- [x] Verified Prometheus 29.14.0 subchart renders cleanly

Co-authored-by: Claude Opus 4.7 <noreply@anthropic.com>