### PR TITLE
feat: update prometheus scrapconfigs and server metrics

### DIFF
--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -13,7 +13,7 @@ dependencies:
   version: 1.23.3
 - name: prometheus
   repository: https://charts.opencsg.com/infra
-  version: 28.6.0
+  version: 29.14.0
 - name: runner
   repository: https://charts.opencsg.com/csghub
   version: 2.2.4
@@ -32,5 +32,5 @@ dependencies:
 - name: agentichub
   repository: https://charts.opencsg.com/csghub
   version: 0.6.2
-digest: sha256:4772f9ed243d2c289741c939564c31dbb84259b3dc3beceb152d4a7f12dda7b7
-generated: "2026-07-07T11:26:23.468448+08:00"
+digest: sha256:d981a563f8cbf27a57fc71e0bad42deded5e58277a89d67b5791a2d0d7b16131
+generated: "2026-07-09T11:19:31.20937+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -48,7 +48,7 @@ dependencies:
     repository: https://charts.opencsg.com/infra
     condition: tempo.enabled
   - name: prometheus
-    version: 28.6.0
+    version: 29.14.0
     repository: https://charts.opencsg.com/infra
     condition: prometheus.enabled
   - name: runner

--- a/charts/csghub/templates/csghub/configmap.yaml
+++ b/charts/csghub/templates/csghub/configmap.yaml
@@ -328,6 +328,12 @@ data:
   {{- $promeHost := include "common.names.custom" (list . "prometheus-server") }}
   {{- $promePort := dig "service" "port" 80 $promeSvc }}
   STARHUB_SERVER_PROMETHEUS_API_ADDRESS: {{ printf "http://%s:%v/api/v1/query" $promeHost $promePort | quote }}
+  STARHUB_SERVER_PROMETHEUS_CPU_LIMIT_METRIC: "kube_pod_container_resource_limits"
+  STARHUB_SERVER_PROMETHEUS_CPU_USAGE_METRIC: "container_cpu_usage_seconds_total"
+  STARHUB_SERVER_PROMETHEUS_MEMORY_USAGE_METRIC: "container_memory_usage_bytes"
+  STARHUB_SERVER_PROMETHEUS_METRIC_KEYS: "pod,service_name,namespace,http_response_status_code,le"
+  STARHUB_SERVER_PROMETHEUS_REQUEST_COUNT_METRIC: "kn_serving_invocation_duration_seconds_count"
+  STARHUB_SERVER_PROMETHEUS_REQUEST_LATENCY_METRIC: "http_server_request_duration_seconds_bucket"
   {{- end }}
 
   ## Server Configuration for Loki

--- a/charts/csghub/templates/envoy-proxy-metrics.yaml
+++ b/charts/csghub/templates/envoy-proxy-metrics.yaml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Service
 metadata:
-  name: envoy-proxy-metrics
+  name: envoy-proxy-listeners-metrics
   namespace: {{ .Release.Namespace }}
   annotations:
     prometheus.io/scrape: 'true'

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -945,61 +945,6 @@ prometheus:
     enabled: false                         # Enable Gateway BasicAuth for Prometheus
     # htpasswd: ""                         # Generate with: htpasswd -nbs <username> <password>
 
-  ## Extra scrape configs for Envoy Gateway / Envoy Proxy metrics
-  ## Scrapes envoy-proxy-*-metrics services exposed by envoy-proxy-metrics.yaml
-  ## templates in csghub and runner charts. Each Service targets one Gateway's
-  ## envoy pods (listeners / knative) via /stats/prometheus on port 19001.
-  extraScrapeConfigs: |
-    - job_name: knative-queue-proxy
-      scrape_interval: 30s
-      scrape_timeout: 10s
-      metrics_path: /metrics
-      kubernetes_sd_configs:
-        - role: endpoints
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_namespace]
-          regex: spaces?(-(stg|stage))?
-          action: keep
-        - source_labels: [__meta_kubernetes_service_label_networking_internal_knative_dev_serviceType]
-          regex: Private
-          action: keep
-        - source_labels: [__meta_kubernetes_endpoint_port_name]
-          regex: http-usermetric
-          action: keep
-        - source_labels: [__meta_kubernetes_pod_node_name]
-          target_label: kubernetes_node
-        - source_labels: [__meta_kubernetes_namespace]
-          target_label: namespace
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_name]
-          target_label: pod
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_name]
-          target_label: pod_name
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_container_name]
-          target_label: container
-          action: replace
-    - job_name: envoy-proxy
-      scrape_interval: 30s
-      scrape_timeout: 10s
-      metrics_path: /stats/prometheus
-      kubernetes_sd_configs:
-        - role: endpoints
-      relabel_configs:
-        - source_labels: [__meta_kubernetes_service_name]
-          regex: envoy-proxy-.*-metrics
-          action: keep
-        - source_labels: [__meta_kubernetes_namespace]
-          target_label: namespace
-          action: replace
-        - source_labels: [__meta_kubernetes_service_name]
-          target_label: service
-          action: replace
-        - source_labels: [__meta_kubernetes_pod_node_name]
-          target_label: node
-          action: replace
-
 ## MemMachine configuration
 memmachine:
   enabled: false

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -945,6 +945,61 @@ prometheus:
     enabled: false                         # Enable Gateway BasicAuth for Prometheus
     # htpasswd: ""                         # Generate with: htpasswd -nbs <username> <password>
 
+  ## Extra scrape configs for Envoy Gateway / Envoy Proxy metrics
+  ## Scrapes envoy-proxy-*-metrics services exposed by envoy-proxy-metrics.yaml
+  ## templates in csghub and runner charts. Each Service targets one Gateway's
+  ## envoy pods (listeners / knative) via /stats/prometheus on port 19001.
+  extraScrapeConfigs: |
+    - job_name: knative-queue-proxy
+      scrape_interval: 30s
+      scrape_timeout: 10s
+      metrics_path: /metrics
+      kubernetes_sd_configs:
+        - role: endpoints
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_namespace]
+          regex: spaces?(-(stg|stage))?
+          action: keep
+        - source_labels: [__meta_kubernetes_service_label_networking_internal_knative_dev_serviceType]
+          regex: Private
+          action: keep
+        - source_labels: [__meta_kubernetes_endpoint_port_name]
+          regex: http-usermetric
+          action: keep
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          target_label: kubernetes_node
+        - source_labels: [__meta_kubernetes_namespace]
+          target_label: namespace
+          action: replace
+        - source_labels: [__meta_kubernetes_pod_name]
+          target_label: pod
+          action: replace
+        - source_labels: [__meta_kubernetes_pod_name]
+          target_label: pod_name
+          action: replace
+        - source_labels: [__meta_kubernetes_pod_container_name]
+          target_label: container
+          action: replace
+    - job_name: envoy-proxy
+      scrape_interval: 30s
+      scrape_timeout: 10s
+      metrics_path: /stats/prometheus
+      kubernetes_sd_configs:
+        - role: endpoints
+      relabel_configs:
+        - source_labels: [__meta_kubernetes_service_name]
+          regex: envoy-proxy-.*-metrics
+          action: keep
+        - source_labels: [__meta_kubernetes_namespace]
+          target_label: namespace
+          action: replace
+        - source_labels: [__meta_kubernetes_service_name]
+          target_label: service
+          action: replace
+        - source_labels: [__meta_kubernetes_pod_node_name]
+          target_label: node
+          action: replace
+
 ## MemMachine configuration
 memmachine:
   enabled: false


### PR DESCRIPTION
## Summary
- Bump prometheus subchart from 28.6.0 to 29.14.0
- Enable envoy proxy metrics scraping via per-Gateway metrics Services
- Configure default Prometheus metrics collected by csghub server

## Changes
- `charts/csghub/Chart.yaml` / `Chart.lock`: bump prometheus subchart to 29.14.0
- `charts/csghub/templates/csghub/configmap.yaml`: add `STARHUB_SERVER_PROMETHEUS_*` env vars to configure default metrics (CPU limit/usage, memory usage, request count/latency, metric keys)
- `charts/csghub/templates/envoy-proxy-metrics.yaml`: rename metrics Service to `envoy-proxy-listeners-metrics` so it only selects the standalone listeners Gateway's envoy pods (per-Gateway metrics Services live in the runner chart)

## Test plan
- [x] `helm template` renders without errors
- [x] `helm unittest charts/csghub` passes
- [x] Verify envoy proxy metrics (`/stats/prometheus`) are scraped in Prometheus UI
- [x] Verify csghub server picks up the configured metric names