### PR TITLE
feat: update reloader to 2.2.14

### DIFF
--- a/charts/agentichub/Chart.lock
+++ b/charts/agentichub/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.2.2
 - name: reloader
   repository: https://charts.opencsg.com/infra
-  version: 2.2.7
+  version: 2.2.14
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
   version: 1.6.7
 - name: memmachine
   repository: https://charts.opencsg.com/infra
   version: 0.1.0
-digest: sha256:784fda8afbb2ca916c1628656515f406bac5fc6e8c55a0fb7b4a02145b43a507
-generated: "2026-06-16T17:30:04.816801+08:00"
+digest: sha256:7f17d04d768f3b9f137ccf54e5be9372b0702307162971de0a3345c4836cc76d
+generated: "2026-07-09T15:51:24.559629+08:00"

--- a/charts/agentichub/Chart.yaml
+++ b/charts/agentichub/Chart.yaml
@@ -30,7 +30,7 @@ dependencies:
     version: 0.2.2
     repository: https://charts.opencsg.com/csghub
   - name: reloader
-    version: 2.2.7
+    version: 2.2.14
     repository: https://charts.opencsg.com/infra
     condition: reloader.enabled
     tags:

--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.2.2
 - name: reloader
   repository: https://charts.opencsg.com/infra
-  version: 2.2.7
+  version: 2.2.14
 - name: loki
   repository: https://charts.opencsg.com/infra
   version: 6.29.0
@@ -32,5 +32,5 @@ dependencies:
 - name: agentichub
   repository: https://charts.opencsg.com/csghub
   version: 0.6.2
-digest: sha256:d981a563f8cbf27a57fc71e0bad42deded5e58277a89d67b5791a2d0d7b16131
-generated: "2026-07-09T11:19:31.20937+08:00"
+digest: sha256:0d62964684a4bbd601f6c02b0407a92a1b8c4f762c4a65473913f2ff4186ff58
+generated: "2026-07-09T16:03:27.598266+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     version: 0.2.2
     repository: https://charts.opencsg.com/csghub
   - name: reloader
-    version: 2.2.7
+    version: 2.2.14
     repository: https://charts.opencsg.com/infra
     condition: reloader.enabled
   - name: loki

--- a/charts/csgship/Chart.lock
+++ b/charts/csgship/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.2.2
 - name: reloader
   repository: https://charts.opencsg.com/infra
-  version: 2.2.7
+  version: 2.2.14
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
   version: 1.6.7
-digest: sha256:6fbdcfdea8555cd049a1c2ce197f43b3a802ab1dd27b6f732a1cad04d4ee91d0
-generated: "2026-06-16T17:29:48.241719+08:00"
+digest: sha256:256c2f5e6e12dcae1d89811c24898ffae641addfd0617ba473b26006fc85160a
+generated: "2026-07-09T15:50:53.489943+08:00"

--- a/charts/csgship/Chart.yaml
+++ b/charts/csgship/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     version: 0.2.2
     repository: https://charts.opencsg.com/csghub
   - name: reloader
-    version: 2.2.7
+    version: 2.2.14
     repository: https://charts.opencsg.com/infra
     condition: reloader.enabled
     tags:

--- a/charts/dataflow/Chart.lock
+++ b/charts/dataflow/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: 0.2.2
 - name: reloader
   repository: https://charts.opencsg.com/infra
-  version: 2.2.7
+  version: 2.2.14
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
   version: 1.6.7
-digest: sha256:6fbdcfdea8555cd049a1c2ce197f43b3a802ab1dd27b6f732a1cad04d4ee91d0
-generated: "2026-06-16T17:29:35.007048+08:00"
+digest: sha256:256c2f5e6e12dcae1d89811c24898ffae641addfd0617ba473b26006fc85160a
+generated: "2026-07-09T15:50:39.186781+08:00"

--- a/charts/dataflow/Chart.yaml
+++ b/charts/dataflow/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     version: 0.2.2
     repository: https://charts.opencsg.com/csghub
   - name: reloader
-    version: 2.2.7
+    version: 2.2.14
     repository: https://charts.opencsg.com/infra
     condition: reloader.enabled
     tags:

--- a/charts/runner/Chart.lock
+++ b/charts/runner/Chart.lock
@@ -4,7 +4,7 @@ dependencies:
   version: 0.2.2
 - name: reloader
   repository: https://charts.opencsg.com/infra
-  version: 2.2.7
+  version: 2.2.14
 - name: prometheus
   repository: https://charts.opencsg.com/infra
   version: 29.14.0
@@ -26,5 +26,5 @@ dependencies:
 - name: agent-sandbox
   repository: https://charts.opencsg.com/csghub
   version: 0.2.1
-digest: sha256:76005cec5be1772dceac2eb8137db6b4549227cd66bdd4a381e143c47f6d6d68
-generated: "2026-07-09T12:32:56.902445+08:00"
+digest: sha256:9fe7821e5bbb73e6435290363a1124c2529f09753d079ab9c3c8fd3bba41d89e
+generated: "2026-07-09T16:03:53.812196+08:00"

--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -39,7 +39,7 @@ dependencies:
     version: 0.2.2
     repository: https://charts.opencsg.com/csghub
   - name: reloader
-    version: 2.2.7
+    version: 2.2.14
     repository: https://charts.opencsg.com/infra
     condition: reloader.enabled
     tags:


### PR DESCRIPTION
## Summary
- Bump `reloader` subchart from 2.2.7 to 2.2.14 across all charts that depend on it

## Changes
Updated `reloader` dependency version in `Chart.yaml` and `Chart.lock` for:
- `charts/agentichub`
- `charts/csghub`
- `charts/csgship`
- `charts/dataflow`
- `charts/runner`

## Test plan
- [ ] `helm dependency build` succeeds for all charts
- [ ] `helm template` renders without errors
- [ ] `helm unittest` passes for affected charts
- [ ] Reloader pod rolls out and watches ConfigMaps/Secrets correctly