### PR TITLE
feat: upgrade gateway-helm to 1.7.5

### DIFF
--- a/charts/agentichub/Chart.lock
+++ b/charts/agentichub/Chart.lock
@@ -7,9 +7,9 @@ dependencies:
   version: 2.2.14
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
-  version: 1.6.7
+  version: 1.7.5
 - name: memmachine
   repository: https://charts.opencsg.com/infra
   version: 0.1.0
-digest: sha256:7f17d04d768f3b9f137ccf54e5be9372b0702307162971de0a3345c4836cc76d
-generated: "2026-07-09T15:51:24.559629+08:00"
+digest: sha256:f12574a040adc22e0ea6e3509eb239fa01328dde7c80719d1144febc10d8e043
+generated: "2026-07-09T16:49:24.262705+08:00"

--- a/charts/agentichub/Chart.yaml
+++ b/charts/agentichub/Chart.yaml
@@ -38,7 +38,7 @@ dependencies:
       - reloader
   - name: gateway-helm
     alias: envoy
-    version: 1.6.7
+    version: 1.7.5
     repository: oci://docker.io/envoyproxy
     condition: envoy.enabled
     tags:

--- a/charts/agentichub/templates/envoy-proxy.yaml
+++ b/charts/agentichub/templates/envoy-proxy.yaml
@@ -19,7 +19,7 @@ spec:
     {{- if regexMatch "^opencsg-registry" .Values.global.image.registry }}
       envoyDeployment:
         container:
-          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.36.4
+          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.37.5
     {{- else }}
       # Helm v4 uses Server-Side Apply (SSA) by default, which treats null
       # fields as explicit null values rather than unset. When the registry is

--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -28,9 +28,9 @@ dependencies:
   version: 0.1.0
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
-  version: 1.6.7
+  version: 1.7.5
 - name: agentichub
   repository: https://charts.opencsg.com/csghub
   version: 0.6.2
-digest: sha256:0d62964684a4bbd601f6c02b0407a92a1b8c4f762c4a65473913f2ff4186ff58
-generated: "2026-07-09T16:03:27.598266+08:00"
+digest: sha256:81897ebbadf396d7ef2de6634a0e24efe12cd5a1b62d8da9b086daa7df809e78
+generated: "2026-07-09T16:41:49.380191+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -69,7 +69,7 @@ dependencies:
     condition: memmachine.enabled
   - name: gateway-helm
     alias: envoy
-    version: 1.6.7
+    version: 1.7.5
     repository: oci://docker.io/envoyproxy
     condition: envoy.enabled
   - name: agentichub

--- a/charts/csghub/templates/envoy-proxy.yaml
+++ b/charts/csghub/templates/envoy-proxy.yaml
@@ -19,7 +19,7 @@ spec:
     {{- if regexMatch "^opencsg-registry" .Values.global.image.registry }}
       envoyDeployment:
         container:
-          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.36.4
+          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.37.5
     {{- else }}
       # Helm v4 uses Server-Side Apply (SSA) by default, which treats null
       # fields as explicit null values rather than unset. When the registry is

--- a/charts/csghub/tests/gateway_test.yaml
+++ b/charts/csghub/tests/gateway_test.yaml
@@ -361,7 +361,7 @@ tests:
           value: 30022
       - equal:
           path: spec.provider.kubernetes.envoyDeployment.container.image
-          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/envoyproxy/envoy:distroless-v1.36.4"
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/envoyproxy/envoy:distroless-v1.37.5"
 
   - it: Should render envoyDeployment as empty object when using non-opencsg registry
     template: envoy-proxy.yaml

--- a/charts/csgship/Chart.lock
+++ b/charts/csgship/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 2.2.14
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
-  version: 1.6.7
-digest: sha256:256c2f5e6e12dcae1d89811c24898ffae641addfd0617ba473b26006fc85160a
-generated: "2026-07-09T15:50:53.489943+08:00"
+  version: 1.7.5
+digest: sha256:1e8710e757abeaa663d382c95d510a57b7a1d4610c550dcca4b89e6a730d9797
+generated: "2026-07-09T16:49:02.326857+08:00"

--- a/charts/csgship/Chart.yaml
+++ b/charts/csgship/Chart.yaml
@@ -44,7 +44,7 @@ dependencies:
       - reloader
   - name: gateway-helm
     alias: envoy
-    version: 1.6.7
+    version: 1.7.5
     repository: oci://docker.io/envoyproxy
     condition: envoy.enabled
     tags:

--- a/charts/csgship/templates/envoy-proxy.yaml
+++ b/charts/csgship/templates/envoy-proxy.yaml
@@ -19,7 +19,7 @@ spec:
     {{- if regexMatch "^opencsg-registry" .Values.global.image.registry }}
       envoyDeployment:
         container:
-          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.36.4
+          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.37.5
     {{- else }}
       # Helm v4 uses Server-Side Apply (SSA) by default, which treats null
       # fields as explicit null values rather than unset. When the registry is

--- a/charts/csgship/tests/gateway_test.yaml
+++ b/charts/csgship/tests/gateway_test.yaml
@@ -103,7 +103,7 @@ tests:
           value: 30444
       - equal:
           path: spec.provider.kubernetes.envoyDeployment.container.image
-          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/envoyproxy/envoy:distroless-v1.36.4"
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/envoyproxy/envoy:distroless-v1.37.5"
 
   - it: Should render envoyDeployment as empty object when using non-opencsg registry
     template: envoy-proxy.yaml

--- a/charts/dataflow/Chart.lock
+++ b/charts/dataflow/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 2.2.14
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
-  version: 1.6.7
-digest: sha256:256c2f5e6e12dcae1d89811c24898ffae641addfd0617ba473b26006fc85160a
-generated: "2026-07-09T15:50:39.186781+08:00"
+  version: 1.7.5
+digest: sha256:1e8710e757abeaa663d382c95d510a57b7a1d4610c550dcca4b89e6a730d9797
+generated: "2026-07-09T16:48:45.839133+08:00"

--- a/charts/dataflow/Chart.yaml
+++ b/charts/dataflow/Chart.yaml
@@ -44,7 +44,7 @@ dependencies:
       - reloader
   - name: gateway-helm
     alias: envoy
-    version: 1.6.7
+    version: 1.7.5
     repository: oci://docker.io/envoyproxy
     condition: envoy.enabled
     tags:

--- a/charts/dataflow/templates/envoy-proxy.yaml
+++ b/charts/dataflow/templates/envoy-proxy.yaml
@@ -19,7 +19,7 @@ spec:
     {{- if regexMatch "^opencsg-registry" .Values.global.image.registry }}
       envoyDeployment:
         container:
-          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.36.4
+          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.37.5
     {{- else }}
       # Helm v4 uses Server-Side Apply (SSA) by default, which treats null
       # fields as explicit null values rather than unset. When the registry is

--- a/charts/dataflow/tests/gateway_test.yaml
+++ b/charts/dataflow/tests/gateway_test.yaml
@@ -110,7 +110,7 @@ tests:
           value: 30444
       - equal:
           path: spec.provider.kubernetes.envoyDeployment.container.image
-          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/envoyproxy/envoy:distroless-v1.36.4"
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/envoyproxy/envoy:distroless-v1.37.5"
 
   - it: Should render envoyDeployment as empty object when using non-opencsg registry
     template: envoy-proxy.yaml

--- a/charts/runner/Chart.lock
+++ b/charts/runner/Chart.lock
@@ -10,7 +10,7 @@ dependencies:
   version: 29.14.0
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
-  version: 1.6.7
+  version: 1.7.5
 - name: lws
   repository: https://charts.opencsg.com/infra
   version: v0.6.1
@@ -26,5 +26,5 @@ dependencies:
 - name: agent-sandbox
   repository: https://charts.opencsg.com/csghub
   version: 0.2.1
-digest: sha256:9fe7821e5bbb73e6435290363a1124c2529f09753d079ab9c3c8fd3bba41d89e
-generated: "2026-07-09T16:03:53.812196+08:00"
+digest: sha256:9dc143aaf0d46f3cd367691c32a1cc3dd053bfccf60aaf1084c42716cf5a49a5
+generated: "2026-07-09T16:46:08.282325+08:00"

--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -54,7 +54,7 @@ dependencies:
       - monitor
   - name: gateway-helm
     alias: envoy
-    version: 1.6.7
+    version: 1.7.5
     repository: oci://docker.io/envoyproxy
     condition: envoy.enabled
     tags:

--- a/charts/runner/templates/envoy-proxy.yaml
+++ b/charts/runner/templates/envoy-proxy.yaml
@@ -23,7 +23,7 @@ spec:
     {{- if $isOpencsg }}
       envoyDeployment:
         container:
-          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.36.4
+          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.37.5
     {{- else }}
       envoyDeployment: {}
     {{- end }}
@@ -72,7 +72,7 @@ spec:
     {{- if $isOpencsg }}
       envoyDeployment:
         container:
-          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.36.4
+          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.37.5
     {{- else }}
       envoyDeployment: {}
     {{- end }}
@@ -107,7 +107,7 @@ spec:
     {{- if $isOpencsg }}
       envoyDeployment:
         container:
-          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.36.4
+          image: {{ .Values.global.image.registry }}/opencsghq/envoyproxy/envoy:distroless-v1.37.5
     {{- else }}
       envoyDeployment: {}
     {{- end }}

--- a/charts/runner/tests/gateway_test.yaml
+++ b/charts/runner/tests/gateway_test.yaml
@@ -112,7 +112,7 @@ tests:
           value: 30444
       - equal:
           path: spec.provider.kubernetes.envoyDeployment.container.image
-          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/envoyproxy/envoy:distroless-v1.36.4"
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/envoyproxy/envoy:distroless-v1.37.5"
 
   - it: Should render envoyDeployment as empty object when using non-opencsg registry
     template: envoy-proxy.yaml


### PR DESCRIPTION
## Summary
- Bump `gateway-helm` subchart from 1.6.7 to 1.7.5 across all charts that depend on it (csghub, runner, csgship, dataflow, agentichub)
- Bump Envoy Proxy data plane image from `distroless-v1.36.4` to `distroless-v1.37.5` (the default in v1.7.5, defined in `api/v1alpha1/shared_types.go`)

## Changes
**Chart.yaml / Chart.lock** — gateway-helm version bump in 5 charts:
- `charts/csghub`, `charts/runner`, `charts/csgship`, `charts/dataflow`, `charts/agentichub`

**Envoy Proxy data plane image** (`distroless-v1.36.4` → `distroless-v1.37.5`) in 8 template locations:
- `charts/csghub/templates/envoy-proxy.yaml`
- `charts/runner/templates/envoy-proxy.yaml` (3 occurrences: knative, knative-local, listeners)
- `charts/csgship/templates/envoy-proxy.yaml`
- `charts/dataflow/templates/envoy-proxy.yaml`
- `charts/agentichub/templates/envoy-proxy.yaml`

**Unit test assertions** — synced expected image tag in 4 test files:
- `charts/csghub/tests/gateway_test.yaml`
- `charts/runner/tests/gateway_test.yaml`
- `charts/csgship/tests/gateway_test.yaml`
- `charts/dataflow/tests/gateway_test.yaml`

## Notes
- The packed `gateway-helm-1.6.7.tgz` was byte-identical to upstream (no custom modifications), so the upgrade is a clean version bump.
- Envoy Proxy data plane image is set via `EnvoyProxy` CRD `spec.provider.kubernetes.envoyDeployment.container.image` in parent templates, independent of the gateway-helm chart version. v1.7.5 source defines `DefaultEnvoyProxyImage = "docker.io/envoyproxy/envoy:distroless-v1.37.5"`.
- `charts/runner/templates/knativeserving.yaml:73` uses `envoy:v1.37-latest` for Knative Kourier gateway (not Envoy Gateway data plane), left unchanged.
- 1.7.5 template/RBAC changes (experimental `xlistenersets` API, `hpa.enabled` guard, `loadBalancerIP`, `GatewayNamespace` RBAC scope) are all internal to the subchart and don't affect parent chart usage.

## Test plan
- [x] `helm dependency build` succeeds for all 5 charts
- [x] `helm template` renders without errors for all 5 charts
- [x] `helm unittest` passes for all 5 charts (208 tests total)
- [x] `yamllint` passes for all charts
- [ ] Verify Envoy Gateway controller pod rolls out successfully
- [ ] Verify Envoy Proxy data plane pods use `distroless-v1.37.5` image
- [ ] Verify existing HTTPRoute/Gateway/EnvoyProxy resources reconcile correctly