### PR TITLE
feat: update runner subcharts

### DIFF
--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -16,7 +16,7 @@ dependencies:
   version: 29.14.0
 - name: runner
   repository: https://charts.opencsg.com/csghub
-  version: 2.2.4
+  version: 2.3.0
 - name: dataflow
   repository: https://charts.opencsg.com/csghub
   version: 2.3.0
@@ -32,5 +32,5 @@ dependencies:
 - name: agentichub
   repository: https://charts.opencsg.com/csghub
   version: 0.6.2
-digest: sha256:6c319f8c3f31ad96b46224ff464b98c550b412721536e8531f09e82d920ea709
-generated: "2026-07-09T17:37:46.6295+08:00"
+digest: sha256:52af5634fcab9f1474af7c8a892466f374048bed48f714a297f9db0435c11aec
+generated: "2026-07-09T19:32:36.334882+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -52,7 +52,7 @@ dependencies:
     repository: https://charts.opencsg.com/infra
     condition: prometheus.enabled
   - name: runner
-    version: 2.2.4
+    version: 2.3.0
     repository: https://charts.opencsg.com/csghub
     condition: runner.enabled
   - name: dataflow

--- a/charts/runner/Chart.lock
+++ b/charts/runner/Chart.lock
@@ -16,15 +16,15 @@ dependencies:
   version: v0.6.1
 - name: argo-workflows
   repository: https://charts.opencsg.com/infra
-  version: 0.47.4
+  version: 0.47.5
 - name: knative-operator
   repository: https://charts.opencsg.com/infra
   version: 1.22.1
 - name: volcano
   repository: https://charts.opencsg.com/infra
-  version: 1.14.1
+  version: 1.14.3
 - name: agent-sandbox
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.1
-digest: sha256:9dc143aaf0d46f3cd367691c32a1cc3dd053bfccf60aaf1084c42716cf5a49a5
-generated: "2026-07-09T16:46:08.282325+08:00"
+  version: 0.4.6
+digest: sha256:fd709fb2a660d40335f4f259c87d7ed59062ccb9001d1f8c35434ba6932ea9a7
+generated: "2026-07-09T19:25:34.99002+08:00"

--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -66,7 +66,7 @@ dependencies:
     condition: lws.enabled
   - name: argo-workflows
     alias: argo
-    version: 0.47.4
+    version: 0.47.5
     repository: https://charts.opencsg.com/infra
     condition: argo.enabled
   - name: knative-operator
@@ -75,10 +75,10 @@ dependencies:
     repository: https://charts.opencsg.com/infra
     condition: knative.enabled
   - name: volcano
-    version: 1.14.1
+    version: 1.14.3
     repository: https://charts.opencsg.com/infra
     condition: volcano.enabled
   - name: agent-sandbox
-    version: 0.2.1
+    version: 0.4.6
     repository: https://charts.opencsg.com/csghub
     condition: agent-sandbox.enabled


### PR DESCRIPTION
## Summary
- Bump argo-workflows subchart from 0.47.4 to 0.47.5 (appVersion v3.7.10 → v3.7.11)
- Bump volcano subchart from 1.14.1 to 1.14.3 (appVersion 1.14.1 → 1.14.3)
- Bump agent-sandbox subchart from 0.2.1 to 0.4.6 (appVersion 0.2.1 → 0.4.6)

## Changes
- `charts/runner/Chart.yaml`: bump 3 subchart versions
- `charts/runner/Chart.lock`: synced digest and generated timestamp

## Notes
- argo-workflows 0.47.5: only Chart.yaml changed (version/appVersion/description), templates identical to 0.47.4
- volcano 1.14.3: templates identical to 1.14.1, only Chart.yaml/values.yaml/policy changed; local customizations (common.image helper, resourceclaims/binding RBAC) preserved
- agent-sandbox 0.4.6: regenerated from upstream v0.4.6 via chart.sh, see PR #657

## Test plan
- [x] `helm dependency build` succeeds
- [x] `helm template` renders without errors
- [x] `helm unittest` passes (30 tests)
- [ ] Verify argo-workflows controller rolls out
- [ ] Verify volcano scheduler/controller/webhook roll out
- [ ] Verify agent-sandbox controller rolls out