### PR TITLE
feat: update built-in component images

### DIFF
--- a/charts/agentichub/values.yaml
+++ b/charts/agentichub/values.yaml
@@ -258,7 +258,7 @@ postgresql:
   image:
     # registry: "docker.io"
     repository: "opencsghq/postgres"
-    tag: "15.17"                             # Image version tag
+    tag: "15.18"                             # Image version tag
     pullPolicy: "IfNotPresent"               # Image pull policy
     pullSecrets: []                          # Docker registry secrets
 
@@ -284,7 +284,7 @@ redis:
   image:
     # registry: "docker.io"
     repository: "redis"
-    tag: "7.2.5"                             # Image version tag
+    tag: "7.4.9"                             # Image version tag
     pullPolicy: "IfNotPresent"               # Image pull policy
     pullSecrets: []                          # Docker registry secrets
 

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -566,7 +566,7 @@ postgresql:
   image:
     # registry: "docker.io"
     repository: "opencsghq/postgres"
-    tag: "15.17"                             # Image version tag
+    tag: "15.18"                             # Image version tag
     pullPolicy: "IfNotPresent"               # Image pull policy
     pullSecrets: []                          # Docker registry secrets
 
@@ -600,7 +600,7 @@ redis:
   image:
     # registry: "docker.io"
     repository: "redis"
-    tag: "7.2.5"                             # Image version tag
+    tag: "7.4.9"                             # Image version tag
     pullPolicy: "IfNotPresent"               # Image pull policy
     pullSecrets: []                          # Docker registry secrets
 
@@ -753,7 +753,7 @@ nats:
   image:
     # registry: "docker.io"
     repository: "nats"
-    tag: "2.10.16"                           # Image version tag
+    tag: "2.12.12"                           # Image version tag
     pullPolicy: "IfNotPresent"               # Image pull policy
     pullSecrets: []                          # Docker registry secrets
 
@@ -805,7 +805,7 @@ temporal:
   image:
     # registry: "docker.io"
     repository: "temporalio/auto-setup"
-    tag: "1.25.1"                            # Image version tag
+    tag: "1.29.7"                            # Image version tag
     pullPolicy: "IfNotPresent"               # Image pull policy
     pullSecrets: []                          # Docker registry secrets
 
@@ -818,7 +818,7 @@ temporal:
     enabled: false                           # Enable console UI
     image:
       repository: "temporalio/ui"            # Console UI image repository
-      tag: "2.30.3"                          # Console UI image tag
+      tag: "2.48.4"                          # Console UI image tag
     service:
       port: 8080                             # Console service port
       protocol: "TCP"                        # Network protocol

--- a/charts/csgship/values.yaml
+++ b/charts/csgship/values.yaml
@@ -202,7 +202,7 @@ postgresql:
   image:
     # registry: "docker.io"
     repository: "opencsghq/postgres"
-    tag: "15.17"                             # Image version tag
+    tag: "15.18"                             # Image version tag
     pullPolicy: "IfNotPresent"               # Image pull policy
     pullSecrets: []                          # Docker registry secrets
 
@@ -229,7 +229,7 @@ redis:
   image:
     # registry: "docker.io"
     repository: "redis"
-    tag: "7.2.5"                             # Image version tag
+    tag: "7.4.9"                             # Image version tag
     pullPolicy: "IfNotPresent"               # Image pull policy
     pullSecrets: []                          # Docker registry secrets
 

--- a/charts/dataflow/values.yaml
+++ b/charts/dataflow/values.yaml
@@ -161,7 +161,7 @@ postgresql:
   image:
     # registry: "docker.io"
     repository: "opencsghq/postgres"
-    tag: "15.17"                             # Image version tag
+    tag: "15.18"                             # Image version tag
     pullPolicy: "IfNotPresent"               # Image pull policy
     pullSecrets: []                          # Docker registry secrets
 


### PR DESCRIPTION
## Summary

- Upgrade built-in PostgreSQL from 15.17 to 15.18 across csghub, csgship, dataflow, agentichub
- Upgrade built-in Redis from 7.2.5 to 7.4.9 across csghub, csgship, agentichub
- Upgrade built-in NATS from 2.10.16 to 2.12.12 in csghub
- Upgrade Temporal auto-setup from 1.25.1 to 1.29.7 and Temporal UI from 2.30.3 to 2.48.4 in csghub

## Test plan

- [ ] Verify `helm template` renders correct image tags for all components
- [ ] Verify existing PVCs are preserved during upgrade (helm.sh/resource-policy: keep)
- [ ] Verify PostgreSQL 15.18 data directory format is compatible with existing volumes
- [ ] Verify Redis 7.4.9 RDB/AOF format compatibility with existing data
- [ ] Verify Temporal auto-setup runs schema migration on startup
- [ ] Verify NATS JetStream data directory is compatible