### PR TITLE
fix: persist temporal Casdoor OAuth credentials across upgrades

### DIFF
--- a/charts/csghub/templates/temporal/configmap.yaml
+++ b/charts/csghub/templates/temporal/configmap.yaml
@@ -20,7 +20,7 @@ data:
   TEMPORAL_CORS_ORIGINS: {{ include "common.endpoint.csghub" . | quote }}
   TEMPORAL_CSRF_COOKIE_INSECURE: "true"
   TEMPORAL_UI_PUBLIC_PATH: "/-/temporal"
-  {{- $data := (lookup "v1" "ConfigMap" .Release.Namespace (include "common.names.custom" (list . "core"))).data | default dict }}
+  {{- $data := (lookup "v1" "ConfigMap" .Release.Namespace $serviceName).data | default dict }}
   {{- $app := include "csghub.casdoor.client" "Admin" | fromYaml }}
   {{- $casdoorClientID := dig "TEMPORAL_AUTH_CLIENT_ID" $app.clientId $data }}
   {{- $casdoorClientSecret := dig "TEMPORAL_AUTH_CLIENT_SECRET" $app.clientSecret $data }}


### PR DESCRIPTION
## Summary

The temporal ConfigMap's Casdoor OAuth credentials (`TEMPORAL_AUTH_CLIENT_ID` / `TEMPORAL_AUTH_CLIENT_SECRET`) were generated from a timestamp-based helper that changes every hour. The ConfigMap's `lookup` was checking the wrong ConfigMap (core), so `dig` always fell back to the regenerated value instead of persisting the original.

## Changes

- `charts/csghub/templates/temporal/configmap.yaml`: Changed the `lookup` target from the core ConfigMap to the temporal ConfigMap itself (self-lookup), so OAuth credentials are persisted once written and stable across Helm upgrades.

## Background

The `csghub.casdoor.client` helper uses `now | date "2006010215"` (hourly seed) to generate client_id/client_secret. The temporal ConfigMap's data feeds into `casdoor/job.yaml` via `envFrom`, which runs a SQL migration that writes these credentials into the Casdoor Admin application. Every Helm upgrade re-runs the job, and without self-lookup persistence, the Admin app's OAuth credentials could change, breaking SSO integrations (Superset, Temporal UI, etc.).