### PR TITLE
fix: persist casdoor admin credentials in init secret

### DIFF
--- a/charts/csghub/templates/casdoor/job.yaml
+++ b/charts/csghub/templates/casdoor/job.yaml
@@ -117,17 +117,13 @@ spec:
               value: "$(STARHUB_SERVER_CASDOOR_CLIENT_ID)"
             - name: CSGHUB_CLIENT_SECRET
               value: "$(STARHUB_SERVER_CASDOOR_CLIENT_SECRET)"
-            {{- if .Values.temporal.console.enabled }}
             - name: ADMIN_CLIENT_ID
-              value: "$(TEMPORAL_AUTH_CLIENT_ID)"
+              value: "$(CASDOOR_ADMIN_CLIENT_ID)"
             - name: ADMIN_CLIENT_SECRET
-              value: "$(TEMPORAL_AUTH_CLIENT_SECRET)"
-            {{- end }}
-            {{- if .Values.csgship.enabled }}
+              value: "$(CASDOOR_ADMIN_CLIENT_SECRET)"
             {{- if .Values.csgship.enabled }}
             - name: CSGSHIP_EXTERNAL_ENDPOINT
               value: {{ include "common.endpoint.web" . | quote }}
-            {{- end }}
             {{- $webSvc := include "common.service" (dict "ctx" . "service" "web") | fromYaml }}
             - name: OAUTH_CLIENT_ID
               value: {{ dig "oauth" "clientId" "" $webSvc | quote }}

--- a/charts/csghub/templates/casdoor/secret.yaml
+++ b/charts/csghub/templates/casdoor/secret.yaml
@@ -30,6 +30,12 @@ data:
   {{- end }}
   INIT_ADMIN_PASSWORD: {{ $secretPass | default (b64enc $defaultPass) | quote }}
   INIT_ADMIN_HTPASSWD: {{ $secretHtpasswd | default (b64enc $defaultHtpasswd) | quote }}
+  {{- $adminApp := include "csghub.casdoor.client" "Admin" | fromYaml }}
+  {{- $casdoorInitData := ($existingSecret.data) | default dict }}
+  {{- $adminClientID := dig "CASDOOR_ADMIN_CLIENT_ID" (b64enc $adminApp.clientId) $casdoorInitData }}
+  {{- $adminClientSecret := dig "CASDOOR_ADMIN_CLIENT_SECRET" (b64enc $adminApp.clientSecret) $casdoorInitData }}
+  CASDOOR_ADMIN_CLIENT_ID: {{ $adminClientID | quote }}
+  CASDOOR_ADMIN_CLIENT_SECRET: {{ $adminClientSecret | quote }}
 ---
 apiVersion: v1
 kind: Secret

--- a/charts/csghub/templates/superset/secret.yaml
+++ b/charts/csghub/templates/superset/secret.yaml
@@ -6,47 +6,21 @@ SPDX-License-Identifier: Apache-2.0
 {{- if .Values.superset.enabled }}
 {{- $secretName := include "common.names.custom" (list . "superset-env") }}
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName }}
-{{- $existingKey := "" }}
-{{- if $existingSecret }}
-{{- $existingKey = (($existingSecret.data).SUPERSET_SECRET_KEY) }}
-{{- end }}
+{{- $existingKey := ($existingSecret.data).SUPERSET_SECRET_KEY }}
 {{- $casdoorEndpoint := include "common.endpoint.casdoor" . }}
-{{- $temporalSvc := include "common.service" (dict "ctx" . "service" "temporal") | fromYaml }}
-{{- $temporalName := include "common.names.custom" (list . $temporalSvc.name) }}
-{{- $temporalData := (lookup "v1" "ConfigMap" .Release.Namespace $temporalName).data | default dict }}
-{{- $existingData := (lookup "v1" "Secret" .Release.Namespace $secretName).data | default dict }}
-{{- $casdoorApp := include "csghub.casdoor.client" "Admin" | fromYaml }}
-{{- $clientIdRaw := $casdoorApp.clientId }}
-{{- $tmpClientId := dig "TEMPORAL_AUTH_CLIENT_ID" "" $temporalData }}
-{{- if $tmpClientId }}
-{{- $clientIdRaw = $tmpClientId }}
-{{- else }}
-{{- $tmpClientId = dig "CASDOOR_CLIENT_ID" "" $existingData }}
-{{- if $tmpClientId }}
-{{- $clientIdRaw = $tmpClientId | b64dec }}
-{{- end }}
-{{- end }}
-{{- $clientSecretRaw := $casdoorApp.clientSecret }}
-{{- $tmpClientSecret := dig "TEMPORAL_AUTH_CLIENT_SECRET" "" $temporalData }}
-{{- if $tmpClientSecret }}
-{{- $clientSecretRaw = $tmpClientSecret }}
-{{- else }}
-{{- $tmpClientSecret = dig "CASDOOR_CLIENT_SECRET" "" $existingData }}
-{{- if $tmpClientSecret }}
-{{- $clientSecretRaw = $tmpClientSecret | b64dec }}
-{{- end }}
-{{- end }}
+{{- $casdoorInitName := printf "%s-init" (include "common.names.custom" (list . "casdoor")) }}
+{{- $casdoorInitData := (lookup "v1" "Secret" .Release.Namespace $casdoorInitName).data | default dict }}
+{{- $adminApp := include "csghub.casdoor.client" "Admin" | fromYaml }}
+{{- $adminClientID := or (dig "CASDOOR_ADMIN_CLIENT_ID" "" $casdoorInitData | b64dec) $adminApp.clientId }}
+{{- $adminClientSecret := or (dig "CASDOOR_ADMIN_CLIENT_SECRET" "" $casdoorInitData | b64dec) $adminApp.clientSecret }}
 {{- $supersetSvc := dict "name" "superset" "postgresql" (dict "database" "csghub_superset") }}
 {{- $pgConfig := include "common.postgresql.config" (dict "ctx" . "service" $supersetSvc) | fromYaml }}
 {{- $redisConfig := include "common.redis.config" (dict "ctx" . "service" (dict)) | fromYaml }}
 {{- $serverSvc := include "common.service" (dict "ctx" . "service" "server") | fromYaml }}
 {{- $serverPgConfig := include "common.postgresql.config" (dict "ctx" . "service" $serverSvc) | fromYaml }}
 {{- $casdoorSvc := include "common.service" (dict "ctx" . "service" "casdoor") | fromYaml }}
-{{- $casdoorInitSecret := lookup "v1" "Secret" .Release.Namespace (printf "%s-init" (include "common.names.custom" (list . $casdoorSvc.name))) }}
-{{- $adminPass := $casdoorSvc.admin.password | default (include "common.randomPassword" $casdoorSvc.name) }}
-{{- if $casdoorInitSecret }}
-{{- $adminPass = (($casdoorInitSecret.data).INIT_ADMIN_PASSWORD) | b64dec | default $adminPass }}
-{{- end }}
+{{- $randomPass := include "common.randomPassword" $casdoorSvc.name }}
+{{- $adminPass := or $casdoorSvc.admin.password (dig "INIT_ADMIN_PASSWORD" "" $casdoorInitData | b64dec) $randomPass }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -61,8 +35,8 @@ data:
   SUPERSET_SECRET_KEY: {{ $existingKey | default (randAlphaNum 56 | b64enc) | quote }}
   ADMIN_PASSWORD: {{ $adminPass | b64enc | quote }}
   CASDOOR_ENDPOINT: {{ $casdoorEndpoint | b64enc | quote }}
-  CASDOOR_CLIENT_ID: {{ $clientIdRaw | b64enc | quote }}
-  CASDOOR_CLIENT_SECRET: {{ $clientSecretRaw | b64enc | quote }}
+  CASDOOR_CLIENT_ID: {{ $adminClientID | b64enc | quote }}
+  CASDOOR_CLIENT_SECRET: {{ $adminClientSecret | b64enc | quote }}
   DB_HOST: {{ $pgConfig.host | b64enc | quote }}
   DB_PORT: {{ $pgConfig.port | toString | b64enc | quote }}
   DB_USER: {{ $pgConfig.user | b64enc | quote }}

--- a/charts/csghub/templates/temporal/configmap.yaml
+++ b/charts/csghub/templates/temporal/configmap.yaml
@@ -20,16 +20,17 @@ data:
   TEMPORAL_CORS_ORIGINS: {{ include "common.endpoint.csghub" . | quote }}
   TEMPORAL_CSRF_COOKIE_INSECURE: "true"
   TEMPORAL_UI_PUBLIC_PATH: "/-/temporal"
-  {{- $data := (lookup "v1" "ConfigMap" .Release.Namespace $serviceName).data | default dict }}
-  {{- $app := include "csghub.casdoor.client" "Admin" | fromYaml }}
-  {{- $casdoorClientID := dig "TEMPORAL_AUTH_CLIENT_ID" $app.clientId $data }}
-  {{- $casdoorClientSecret := dig "TEMPORAL_AUTH_CLIENT_SECRET" $app.clientSecret $data }}
+  {{- $casdoorInitName := printf "%s-init" (include "common.names.custom" (list . "casdoor")) }}
+  {{- $casdoorInitData := (lookup "v1" "Secret" .Release.Namespace $casdoorInitName).data | default dict }}
+  {{- $adminApp := include "csghub.casdoor.client" "Admin" | fromYaml }}
+  {{- $adminClientID := or (dig "CASDOOR_ADMIN_CLIENT_ID" "" $casdoorInitData | b64dec) $adminApp.clientId }}
+  {{- $adminClientSecret := or (dig "CASDOOR_ADMIN_CLIENT_SECRET" "" $casdoorInitData | b64dec) $adminApp.clientSecret }}
   TEMPORAL_AUTH_ENABLED: "true"
   TEMPORAL_AUTH_TYPE: "oidc"
   TEMPORAL_AUTH_PROVIDER_URL: {{ include "common.endpoint.casdoor" . | quote }}
   TEMPORAL_AUTH_ISSUER_URL: {{ include "common.endpoint.casdoor" . | quote }}
-  TEMPORAL_AUTH_CLIENT_ID: {{ $casdoorClientID | quote }}
-  TEMPORAL_AUTH_CLIENT_SECRET: {{ $casdoorClientSecret | quote }}
+  TEMPORAL_AUTH_CLIENT_ID: {{ $adminClientID | quote }}
+  TEMPORAL_AUTH_CLIENT_SECRET: {{ $adminClientSecret | quote }}
   TEMPORAL_AUTH_CALLBACK_URL: {{ printf "%s/-/temporal/auth/sso/callback" (include "common.endpoint.csghub" .) | quote }}
   TEMPORAL_AUTH_SCOPES: "openid,email,profile"
 {{- end }}


### PR DESCRIPTION
## Summary

Persist Casdoor Admin application OAuth credentials in the `casdoor-init` Secret as the single source of truth, replacing the hourly-seeded helper that could change values across Helm upgrades.

## Background

The `csghub.casdoor.client` helper generates `client_id`/`client_secret` using `now | date "2006010215"` (hourly seed). The Temporal ConfigMap's `lookup` was checking the wrong ConfigMap (core), so `dig` always fell back to the regenerated value. Every Helm upgrade re-ran the Casdoor Job, which unconditionally overwrote the Admin app's credentials in the Casdoor DB via SQL migration, breaking SSO integrations (Superset, Temporal UI).

## Changes

- **`casdoor/secret.yaml`**: Add `CASDOOR_ADMIN_CLIENT_ID/SECRET` to the init Secret. Use `dig` to persist existing values across upgrades; default to helper output (b64-encoded) on first deploy.
- **`casdoor/job.yaml`**: `ADMIN_CLIENT_ID/SECRET` now reads from `$(CASDOOR_ADMIN_CLIENT_ID/SECRET)` via `envFrom`, unconditionally (no longer gated by `temporal.console.enabled`). Also removed a duplicate `{{- if .Values.csgship.enabled }}` block.
- **`temporal/configmap.yaml`**: Read Admin credentials from the init Secret with `or (dig ... | b64dec) $adminApp.clientId` fallback.
- **`superset/secret.yaml`**: Same `or` + `dig` + `b64dec` pattern. Removed the temporal ConfigMap dependency. Admin password priority: user-configured > init Secret > random.

## Data Flow

```
casdoor-init Secret (resource-policy: keep, persisted)
  ├──→ casdoor/job.yaml        envFrom direct injection
  ├──→ temporal/configmap.yaml lookup
  └──→ superset/secret.yaml     lookup
```

All consumers read from the casdoor-init Secret. The helper is only used as a first-deploy fallback.

## Test Plan

- [x] `helm template` renders correctly with `temporal.console.enabled=true` and `superset.enabled=true`
- [x] `CASDOOR_ADMIN_CLIENT_ID` in superset Secret matches `CASDOOR_ADMIN_CLIENT_ID` in casdoor-init Secret
- [x] `TEMPORAL_AUTH_CLIENT_ID` matches the same value
- [x] User-configured `casdoor.admin.password` takes priority over init Secret value
- [x] yamllint passes (line-length fixed in temporal/superset)