### PR TITLE
feat(csghub): add superset i18n support and pin image tag

### DIFF
--- a/charts/csghub/templates/superset/_superset.tpl
+++ b/charts/csghub/templates/superset/_superset.tpl
@@ -79,12 +79,18 @@ TALISMAN_ENABLED = False
 # The frontend then prepends app_root again, causing a double prefix.
 APP_ICON = "/-/superset/static/assets/images/superset-logo-horiz.png"
 
-# Enable language picker and default to Chinese
-LANGUAGES = {
-    "en": {"flag": "us", "name": "English"},
-    "zh": {"flag": "cn", "name": "中文"},
-}
-BABEL_DEFAULT_LOCALE = "en"
+# Enable language picker and default locale, driven by env vars injected via
+# the superset-env secret (SUPERSET_ENABLED_LANGUAGES / SUPERSET_DEFAULT_LOCALE).
+_enabled_langs = os.environ.get('SUPERSET_ENABLED_LANGUAGES', 'en,zh')
+LANGUAGES = {}
+for _code in [c.strip() for c in _enabled_langs.split(',') if c.strip()]:
+    if _code == 'en':
+        LANGUAGES[_code] = {"flag": "us", "name": "English"}
+    elif _code == 'zh':
+        LANGUAGES[_code] = {"flag": "cn", "name": "中文"}
+    else:
+        LANGUAGES[_code] = {"flag": _code, "name": _code}
+BABEL_DEFAULT_LOCALE = os.environ.get('SUPERSET_DEFAULT_LOCALE', 'en')
 
 AUTH_ROLE_PUBLIC = "Public"
 PUBLIC_ROLE_LIKE = "Public"

--- a/charts/csghub/templates/superset/secret.yaml
+++ b/charts/csghub/templates/superset/secret.yaml
@@ -49,6 +49,9 @@ data:
   TARGET_DB_NAME: {{ $serverPgConfig.database | b64enc | quote }}
   REDIS_HOST: {{ $redisConfig.host | b64enc | quote }}
   REDIS_PORT: {{ $redisConfig.port | toString | b64enc | quote }}
+  BUILD_TRANSLATIONS: {{ "true" | b64enc | quote }}
+  SUPERSET_ENABLED_LANGUAGES: {{ "en,zh,zh_TW" | b64enc | quote }}
+  SUPERSET_DEFAULT_LOCALE: {{ "zh" | b64enc | quote }}
 {{- if or (and .Values.global.redis.enabled .Values.redis.requirePass) (and (not .Values.global.redis.enabled) $redisConfig.password) }}
   REDIS_PASSWORD: {{ $redisConfig.password | b64enc | quote }}
 {{- end }}

--- a/charts/csghub/values.yaml
+++ b/charts/csghub/values.yaml
@@ -971,6 +971,10 @@ envoy:
 ## ref: https://github.com/apache/superset/tree/master/helm/superset
 superset:
   enabled: false
+
+  image:
+    tag: "6.1.0-csg"
+
   secretEnv:
     create: false
   postgresql:


### PR DESCRIPTION
## Summary

Add i18n (internationalization) support to the bundled Apache Superset.

- **`superset/secret.yaml`**: inject new env vars into the `superset-env` secret, which all Superset pods consume via `envFromSecret`:
  - `BUILD_TRANSLATIONS=true`
  - `SUPERSET_ENABLED_LANGUAGES=en,zh,zh_TW`
  - `SUPERSET_DEFAULT_LOCALE=zh`
- **`superset/_superset.tpl`**: build `LANGUAGES` and `BABEL_DEFAULT_LOCALE` in the config override from those env vars instead of hardcoding them, so the language picker and default locale follow the injected values. Other locales fall back to their language code with a neutral flag.
- **`values.yaml`**: pin the Superset image tag to `6.1.0-csg` (the translation-enabled image).

## Notes

- The `SUPERSET_PORT` env var is intentionally not set here — the subchart already injects it from `superset.service.port` (explicit env takes precedence over `envFrom`). Use `--set superset.service.port=28088` to change the port.
- `BUILD_TRANSLATIONS` is a build-time arg in the official Superset Docker image and has no effect at runtime; it is included for parity with the compose config.

## Test plan

- [ ] `helm template` renders the `superset_config.py` override with valid Python syntax
- [ ] `helm unittest` passes for the csghub chart
- [ ] With `superset.enabled=true`, verify the Superset language picker lists en / zh / zh_TW and defaults to Chinese

🤖 Generated with [Claude Code](https://claude.com/claude-code)