### PR TITLE
fix(csghub): add Tag field to OpenCSG casdoor organization

### DIFF
--- a/charts/csghub/scripts/1785988723_casdoor_add_tag_account_item.sql
+++ b/charts/csghub/scripts/1785988723_casdoor_add_tag_account_item.sql
@@ -1,0 +1,41 @@
+--
+-- Append the "Tag" field to the OpenCSG organization's account_items
+--
+-- The Tag entry is already declared in init_data.json, but casdoor's
+-- initDataNewOnly=true means existing organizations are NOT re-seeded on
+-- redeploy, so deployments created before Tag was added lack it in the DB.
+-- This appends the entry idempotently for the OpenCSG organization.
+--
+
+SELECT now() as "Execute Timestamp";
+
+SELECT pg_catalog.set_config('search_path', 'public', false);
+
+DO $$
+DECLARE
+    org_name text := 'OpenCSG';
+    tag_item jsonb := '{"name":"Tag","visible":true,"viewRule":"Public","modifyRule":"Admin","regex":""}';
+    current_items jsonb;
+BEGIN
+    SELECT account_items::jsonb INTO current_items
+    FROM organization
+    WHERE name = org_name;
+
+    IF current_items IS NULL THEN
+        RAISE NOTICE 'Organization % not found, skipping', org_name;
+        RETURN;
+    END IF;
+
+    IF EXISTS (
+        SELECT 1 FROM jsonb_array_elements(current_items) item
+        WHERE item->>'name' = 'Tag'
+    ) THEN
+        RAISE NOTICE 'Tag already present in % account_items, skipping', org_name;
+    ELSE
+        UPDATE organization
+        SET account_items = (current_items || tag_item)::text
+        WHERE name = org_name;
+
+        RAISE NOTICE 'Tag appended to % account_items', org_name;
+    END IF;
+END $$;

--- a/charts/csghub/templates/casdoor/configmap.yaml
+++ b/charts/csghub/templates/casdoor/configmap.yaml
@@ -193,6 +193,13 @@ data:
               "viewRule": "Admin",
               "modifyRule": "Admin",
               "regex": ""
+            },
+            {
+              "name": "Tag",
+              "visible": true,
+              "viewRule": "Public",
+              "modifyRule": "Admin",
+              "regex": ""
             }
           ]
         }


### PR DESCRIPTION
## Summary

Add the `Tag` field to the `OpenCSG` organization's `account_items` in Casdoor.

- **`charts/csghub/scripts/1785988723_casdoor_add_tag_account_item.sql`**: new migration script that idempotently appends the Tag account item (`{"name":"Tag","visible":true,"viewRule":"Public","modifyRule":"Admin","regex":""}`) to the OpenCSG organization in the `csghub_casdoor` DB.
- **`charts/csghub/templates/casdoor/configmap.yaml`**: declare the Tag entry in `init_data.json` for fresh deployments.

## Background

The Tag entry is already declared in `init_data.json`, but Casdoor runs with `initDataNewOnly=true`, so existing organizations are **not** re-seeded on redeploy. Deployments created before the Tag entry was added therefore lack it in the DB. The SQL script covers existing installations; the `init_data.json` change covers fresh ones. Casdoor's init job re-runs all `scripts/*_casdoor_*.sql` on every upgrade, so the script is written to be idempotent (skips if the Tag item is already present).

## Test plan

- [ ] Verified against a live cluster: script appends Tag to `OpenCSG` (15 items), and re-running prints `Tag already present, skipping`
- [ ] `helm template` renders the new script into the casdoor configmap
- [ ] On fresh deploy, Tag appears via `init_data.json`
