### PR TITLE
feat(csghub): preload timescaledb in builtin postgresql

### DIFF
--- a/charts/csghub/templates/postgresql/configmap.yaml
+++ b/charts/csghub/templates/postgresql/configmap.yaml
@@ -18,6 +18,7 @@ data:
   runtime.conf: |
     include_if_exists = '/var/lib/postgresql/data/postgresql.conf'
     max_connections = 300
+    shared_preload_libraries = timescaledb
     {{- range $key, $value := $service.parameters -}}
       {{- if and $key $value }}
     {{ printf "%s = %s" $key ($value | toString | squote ) }}


### PR DESCRIPTION
## Summary

Preload the `timescaledb` extension in the built-in PostgreSQL so that databases can `CREATE EXTENSION timescaledb` without rebuilding the cluster.

- `chcharts/csghub/templates/postgresql/configmap.yaml`: add `shared_preload_libraries = timescaledb` to the generated `runtime.conf`, placed after `include_if_exists` for the data-dir `postgresql.conf` so the preload takes precedence over any commented/default value.

## Background

The built-in image (`opencsghq/postgres:15.18`) already ships `timescaledb.so` under `/usr/lib/postgresql/15/lib/`, but `shared_preload_libraries` is not set, so even after `CREATE EXTENSION timescaledb` the library is not loaded at server start. Enabling it here prepares the cluster to host TimescaleDB-backed features (e.g., the dataflow metrics / time-series workloads).

## Notes

- Gated by `global.postgresql.enabled`; external PostgreSQL setups do not render this configmap, so they are unaffected.
- `shared_preload_libraries` is a **restart-level** setting (not reloadable). StatefulSet has `reloader.stakater.com/auto: true` so a configmap change triggers a rollout restart and the new value takes effect on next pod start.
- Existing installs that already initialized the data dir will pick up the preload on the next rollout restart.
- The runtime.conf setting is placed **after** the `include_if_exists` for the data-dir `postgresql.conf`, so it wins even if that file later sets its own preload value.

## Test plan

- [x] Verified `opencsghq/postgres:15.18` ships `/usr/lib/postgresql/15/lib/timescaledb.so` (extension version 2.28.3 available, not yet installed)
- [x] Verified data-dir `postgresql.conf` ships with `#shared_preload_libraries = ''` (commented), no conflict
- [x] `helm template` renders the correct `runtime.conf` order: include → max_connections → shared_preload_libraries

🤖 Generated with [Claude Code](https://claude.com/claude-code)