### PR TITLE
Fix agentichub

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@
 **/.codesouler
 **/.claude
 CLAUDE.md
+charts-analysis.md

--- a/charts/agentichub/Chart.yaml
+++ b/charts/agentichub/Chart.yaml
@@ -16,7 +16,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.6.3
+version: 0.6.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/agentichub/templates/agenticflow/job.yaml
+++ b/charts/agentichub/templates/agenticflow/job.yaml
@@ -35,7 +35,6 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
-{{- end }}
       containers:
         - name: importer
           image: {{ include "common.image.fixed" (dict "ctx" . "service" "agenticflow" "image" "opencsghq/agenticflow-importer:v1.0.4") }}
@@ -70,3 +69,4 @@ spec:
       affinity:
         {{- toYaml $service.affinity | nindent 8 }}
       {{- end }}
+{{- end }}

--- a/charts/agentichub/templates/csgbot/deployment.yaml
+++ b/charts/agentichub/templates/csgbot/deployment.yaml
@@ -95,7 +95,7 @@ spec:
           livenessProbe:
             tcpSocket:
               port: 8070
-            initialDelaySeconds: 100000
+            initialDelaySeconds: 180
             periodSeconds: 5
           {{- if $service.readinessProbe }}
           readinessProbe:

--- a/charts/agentichub/templates/gateway.yaml
+++ b/charts/agentichub/templates/gateway.yaml
@@ -3,7 +3,7 @@ Copyright OpenCSG, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */ -}}
 
-{{- if and (ne .Values.global.edition "ce") (not .Values.global.chartContext.isBuiltIn) .Values.envoy.enabled }}
+{{- if and (ne .Values.global.edition "ce") (not .Values.global.chartContext.isBuiltIn) }}
 {{- $gateway := .Values.global.gateway }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
@@ -42,24 +42,6 @@ spec:
         certificateRefs:
           - kind: Secret
             name: {{ $gateway.tls.secretName }}
-          {{- $casdoorSvc := include "common.service" (dict "ctx" . "service" "casdoor") | fromYaml }}
-          {{- $casdoorGatewayConfig := include "common.gateway.config" (dict "ctx" . "service" $casdoorSvc) | fromYaml }}
-          {{- if ne $casdoorGatewayConfig.tls.secretName $gateway.tls.secretName }}
-          - kind: Secret
-            name: {{ $casdoorGatewayConfig.tls.secretName }}
-          {{- end }}
-          {{- $minioSvc := include "common.service" (dict "ctx" . "service" "minio") | fromYaml }}
-          {{- $minioGatewayConfig := include "common.gateway.config" (dict "ctx" . "service" $minioSvc) | fromYaml }}
-          {{- if ne $minioGatewayConfig.tls.secretName $gateway.tls.secretName }}
-          - kind: Secret
-            name: {{ $minioGatewayConfig.tls.secretName }}
-          {{- end }}
-          {{- $portalSvc := include "common.service" (dict "ctx" . "service" "portal") | fromYaml }}
-          {{- $portalGatewayConfig := include "common.gateway.config" (dict "ctx" . "service" $portalSvc) | fromYaml }}
-          {{- if ne $portalGatewayConfig.tls.secretName $gateway.tls.secretName }}
-          - kind: Secret
-            name: {{ $portalGatewayConfig.tls.secretName }}
-          {{- end }}
       allowedRoutes:
         namespaces:
           from: Same

--- a/charts/agentichub/templates/redis/_redis.tpl
+++ b/charts/agentichub/templates/redis/_redis.tpl
@@ -27,7 +27,7 @@ SPDX-License-Identifier: APACHE-2.0
     - -c
     - |
       {{- if or (and $ctx.Values.global.redis.enabled $redisSvc.requirePass) (and (not $ctx.Values.global.redis.enabled) $redisConfig.password) }}
-      until redis-cli -h {{ $redisConfig.host }} -p {{ $redisConfig.port }} -a {{ $redisConfig.password }} ping | grep -q "PONG";
+      until redis-cli -h {{ $redisConfig.host }} -p {{ $redisConfig.port }} -a {{ $redisConfig.password | quote }} ping | grep -q "PONG";
       {{- else }}
       until redis-cli -h {{ $redisConfig.host }} -p {{ $redisConfig.port }} ping | grep -q "PONG";
       {{- end }}

--- a/charts/agentichub/templates/redis/service.yaml
+++ b/charts/agentichub/templates/redis/service.yaml
@@ -19,7 +19,7 @@ spec:
   clusterIP: None
   ports:
     - port: {{ $service.service.port }}
-      targetPort: 5432
+      targetPort: 6379
       protocol: {{ dig "service" "protocol" "TCP" $service }}
       name: {{ $service.name }}
   selector:

--- a/charts/agentichub/values.yaml
+++ b/charts/agentichub/values.yaml
@@ -158,7 +158,7 @@ agenticflow:
       memory: "512Mi"
     limits:
       cpu: "1"
-      memory: "1024Gi"
+      memory: "1024Mi"
 
 # CSGBot configuration
 csgbot:
@@ -179,7 +179,7 @@ csgbot:
     # port: 8070
 
   ## Credentials Configuration
-  environment: {}
+  environments: {}
 
   ## ConfigMap Configuration
   config:

--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -31,9 +31,9 @@ dependencies:
   version: 1.7.5
 - name: agentichub
   repository: https://charts.opencsg.com/csghub
-  version: 0.6.3
+  version: 0.6.4
 - name: superset
   repository: https://charts.opencsg.com/infra
   version: 0.20.0
-digest: sha256:561976883e2c32f8fa5f53c9218422ad2f7ec0dd31e755975b6912ca75b0daac
-generated: "2026-08-11T10:00:00+08:00"
+digest: sha256:f51bfc6e1b87188cf91b8bb8c91e905418fd38ea20c4399996b690e64e6aeaa0
+generated: "2026-08-11T17:52:08.627218+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -73,7 +73,7 @@ dependencies:
     repository: oci://docker.io/envoyproxy
     condition: envoy.enabled
   - name: agentichub
-    version: 0.6.3
+    version: 0.6.4
     repository: https://charts.opencsg.com/csghub
     condition: agentichub.enabled
   - name: superset

--- a/charts/csghub/templates/redis/_redis.tpl
+++ b/charts/csghub/templates/redis/_redis.tpl
@@ -27,7 +27,7 @@ SPDX-License-Identifier: APACHE-2.0
     - -c
     - |
       {{- if or (and $ctx.Values.global.redis.enabled $redisSvc.requirePass) (and (not $ctx.Values.global.redis.enabled) $redisConfig.password) }}
-      until redis-cli -h {{ $redisConfig.host }} -p {{ $redisConfig.port }} -a {{ $redisConfig.password }} ping | grep -q "PONG";
+      until redis-cli -h {{ $redisConfig.host }} -p {{ $redisConfig.port }} -a {{ $redisConfig.password | quote }} ping | grep -q "PONG";
       {{- else }}
       until redis-cli -h {{ $redisConfig.host }} -p {{ $redisConfig.port }} ping | grep -q "PONG";
       {{- end }}


### PR DESCRIPTION
## Summary

Fixes a set of bugs in the `agentichub` chart that prevented it from deploying correctly, and bumps its version to `0.6.4` (with `csghub` dependency synced).

## agentichub fixes

| Area | Fix |
|---|---|
| **Redis Service** | `targetPort` corrected `5432 → 6379` to match the pod's actual listen port. Previously the `wait-for-redis` init container hung forever with built-in Redis. |
| **Gateway** | Removed the undeclared `.Values.envoy.enabled` from the gate so `GatewayClass`/`Gateway` actually render in standalone mode (EnvoyProxy + HTTPRoutes were being created with no parent Gateway). |
| **Gateway TLS** | Removed stale `casdoor`/`minio`/`portal` `certificateRefs` copied from the `csghub` parent chart — those services don't exist in `agentichub`. |
| **agenticflow Job** | Fixed misplaced `{{- end }}` so the `template-importer` Job renders a complete manifest instead of a bare `containers:` fragment under `edition: ce`. |
| **resource limits** | `agenticflow.resources.limits.memory` corrected `1024Gi → 1024Mi` (was a 1 TiB limit vs a 512Mi request). |
| **csgbot livenessProbe** | `initialDelaySeconds` corrected `100000 → 180` (was ~27.8h, effectively disabling the probe). |
| **wait-for-redis** | Quote the Redis password in the ping command to avoid shell interpretation of special characters. |
| **values naming** | `csgbot.environment` → `csgbot.environments` to match what the template reads. |

## csghub changes

- Bump `agentichub` dependency `0.6.3 → 0.6.4` in `Chart.yaml` / `Chart.lock`.
- Quote the Redis password in `csghub`'s `wait-for-redis` (same fix as agentichub).

## Testing

- `helm lint` passes for both charts.
- `helm template` verified across standalone (ee/ce) and bundle modes — no dangling Gateway/HTTPRoute.
- Chart unit tests pass (`helm unittest`): agentichub, csghub, dataflow, runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
