### PR TITLE
fix(csghub): honor service name overrides in cross-template references

### DIFF
--- a/charts/csghub/templates/casdoor/job.yaml
+++ b/charts/csghub/templates/casdoor/job.yaml
@@ -91,8 +91,9 @@ spec:
             - configMapRef:
                 name: {{ include "common.names.custom" (list . "core") }}
             {{- if .Values.temporal.console.enabled }}
+            {{- $temporalSvc := include "common.service" (dict "ctx" . "service" "temporal") | fromYaml }}
             - configMapRef:
-                name: {{ include "common.names.custom" (list . "temporal") }}
+                name: {{ include "common.names.custom" (list . $temporalSvc.name) }}
             {{- end }}
             {{- if .Values.csgship.enabled }}
             - configMapRef:

--- a/charts/csghub/templates/csghub/httproutes.yaml
+++ b/charts/csghub/templates/csghub/httproutes.yaml
@@ -115,7 +115,7 @@ spec:
     {{- end }}
     {{- if .Values.dataflow.enabled }}
     {{- $dataflowSvc := include "common.service" (dict "ctx" . "service" "dataflow") | fromYaml }}
-    {{- $labelStudioSvcName := include "common.names.custom" (list . "label-studio") }}
+    {{- $labelStudioSvcName := include "common.names.custom" (list . (dig "name" "label-studio" (dig "labelStudio" dict $dataflowSvc))) }}
     - matches:
         - path:
             type: PathPrefix

--- a/charts/csghub/templates/superset/secret.yaml
+++ b/charts/csghub/templates/superset/secret.yaml
@@ -8,7 +8,8 @@ SPDX-License-Identifier: Apache-2.0
 {{- $existingSecret := lookup "v1" "Secret" .Release.Namespace $secretName }}
 {{- $existingKey := ($existingSecret.data).SUPERSET_SECRET_KEY }}
 {{- $casdoorEndpoint := include "common.endpoint.casdoor" . }}
-{{- $casdoorInitName := printf "%s-init" (include "common.names.custom" (list . "casdoor")) }}
+{{- $casdoorSvc := include "common.service" (dict "ctx" . "service" "casdoor") | fromYaml }}
+{{- $casdoorInitName := printf "%s-init" (include "common.names.custom" (list . $casdoorSvc.name)) }}
 {{- $casdoorInitData := (lookup "v1" "Secret" .Release.Namespace $casdoorInitName).data | default dict }}
 {{- $adminApp := include "csghub.casdoor.client" "Admin" | fromYaml }}
 {{- $adminClientID := or (dig "CASDOOR_ADMIN_CLIENT_ID" "" $casdoorInitData | b64dec) $adminApp.clientId }}
@@ -18,7 +19,6 @@ SPDX-License-Identifier: Apache-2.0
 {{- $redisConfig := include "common.redis.config" (dict "ctx" . "service" (dict)) | fromYaml }}
 {{- $serverSvc := include "common.service" (dict "ctx" . "service" "server") | fromYaml }}
 {{- $serverPgConfig := include "common.postgresql.config" (dict "ctx" . "service" $serverSvc) | fromYaml }}
-{{- $casdoorSvc := include "common.service" (dict "ctx" . "service" "casdoor") | fromYaml }}
 {{- $randomPass := include "common.randomPassword" $casdoorSvc.name }}
 {{- $adminPass := or $casdoorSvc.admin.password (dig "INIT_ADMIN_PASSWORD" "" $casdoorInitData | b64dec) $randomPass }}
 apiVersion: v1

--- a/charts/csghub/templates/temporal/configmap.yaml
+++ b/charts/csghub/templates/temporal/configmap.yaml
@@ -20,7 +20,8 @@ data:
   TEMPORAL_CORS_ORIGINS: {{ include "common.endpoint.csghub" . | quote }}
   TEMPORAL_CSRF_COOKIE_INSECURE: "true"
   TEMPORAL_UI_PUBLIC_PATH: "/-/temporal"
-  {{- $casdoorInitName := printf "%s-init" (include "common.names.custom" (list . "casdoor")) }}
+  {{- $casdoorSvc := include "common.service" (dict "ctx" . "service" "casdoor") | fromYaml }}
+  {{- $casdoorInitName := printf "%s-init" (include "common.names.custom" (list . $casdoorSvc.name)) }}
   {{- $casdoorInitData := (lookup "v1" "Secret" .Release.Namespace $casdoorInitName).data | default dict }}
   {{- $adminApp := include "csghub.casdoor.client" "Admin" | fromYaml }}
   {{- $adminClientID := or (dig "CASDOOR_ADMIN_CLIENT_ID" "" $casdoorInitData | b64dec) $adminApp.clientId }}


### PR DESCRIPTION
## Summary

Several templates looked up resources (secrets/configmaps/services) by a **hardcoded name literal**, while the templates that actually **create** those resources derive the name via `common.service` + `common.names.custom`, which honors each component's `.name` override. As a result, overriding a service name (e.g. `.Values.casdoor.name = iam`) silently broke cross-template references.

This change makes every reference use the same `common.service`-based derivation as its creating template.

## Changes

- **`templates/superset/secret.yaml`** — casdoor-init secret lookup now derived from `casdoor.name` (via `common.service "casdoor"`), not the literal `"casdoor"`.
- **`templates/temporal/configmap.yaml`** — same casdoor-init lookup fix.
- **`templates/casdoor/job.yaml`** — temporal configmap ref now derived from `temporal.name`, matching `temporal/service.yaml`/`configmap.yaml`.
- **`templates/csghub/httproutes.yaml`** — label-studio backend ref now derived from `dataflow.labelStudio.name`, matching the dataflow subchart's service.

## Verification

Rendered with both default and override values (`casdoor.name=iam`, `temporal.name=timeline`, `dataflow.labelStudio.name=ls-custom`):

- References match the actually-created resource names (e.g. `iam-init`, `t-timeline`, `t-ls-custom`).
- Default rendering unchanged (still `t-temporal`, `t-label-studio`) — no regression.
- Full chart renders clean in both cases.
- `ct lint` passes (pre-push hook).