### PR TITLE
fix(common): support nested runner config; bump common to 0.2.3

### DIFF
--- a/charts/agent-sandbox/Chart.lock
+++ b/charts/agent-sandbox/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.2
-digest: sha256:615db281d37d3413fc15396d413a66b1829b85d325477caf315f570fcd4f72c6
-generated: "2026-04-07T17:15:57.576276+08:00"
+  version: 0.2.3
+digest: sha256:748fda8ab57d0edd7064ccf112a2caf758f82d668e3d8c757f3a2577b1cc6dcc
+generated: "2026-08-12T12:04:26.560149+08:00"

--- a/charts/agent-sandbox/Chart.yaml
+++ b/charts/agent-sandbox/Chart.yaml
@@ -26,5 +26,5 @@ appVersion: "0.4.6"
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.2
+    version: 0.2.3
     repository: https://charts.opencsg.com/csghub

--- a/charts/agentichub/Chart.lock
+++ b/charts/agentichub/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.2
+  version: 0.2.3
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
@@ -11,5 +11,5 @@ dependencies:
 - name: memmachine
   repository: https://charts.opencsg.com/infra
   version: 0.1.0
-digest: sha256:f12574a040adc22e0ea6e3509eb239fa01328dde7c80719d1144febc10d8e043
-generated: "2026-07-09T16:49:24.262705+08:00"
+digest: sha256:e2f66fdcf2663e171eb38fa5aba692b8fe68ba9c095211bef53ccd2e225d8386
+generated: "2026-08-12T12:04:52.851031+08:00"

--- a/charts/agentichub/Chart.yaml
+++ b/charts/agentichub/Chart.yaml
@@ -27,7 +27,7 @@ appVersion: "v0.6.2"
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.2
+    version: 0.2.3
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/common/Chart.yaml
+++ b/charts/common/Chart.yaml
@@ -18,7 +18,7 @@ type: library
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.2
+version: 0.2.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/common/templates/_namespace.tpl
+++ b/charts/common/templates/_namespace.tpl
@@ -10,10 +10,14 @@ Return Space Namespace.
 {{- $ns := "" }}
 
 {{- $runner := .Values.runner | default dict }}
+{{- /* Support both .Values.runner.* (standalone) and .Values.runner.runner.* (umbrella parent) */}}
+{{- $runnerConfig := $runner.runner | default dict }}
 {{- $merging := "" }}
 
 {{- if hasKey $runner "mergingNamespace" }}
   {{- $merging = $runner.mergingNamespace }}
+{{- else if hasKey $runnerConfig "mergingNamespace" }}
+  {{- $merging = $runnerConfig.mergingNamespace }}
 {{- else if hasKey .Values "mergingNamespace" }}
   {{- $merging = .Values.mergingNamespace }}
 {{- end }}
@@ -22,6 +26,8 @@ Return Space Namespace.
   {{- $ns = .Release.Namespace }}
 {{- else if hasKey $runner "namespace" }}
   {{- $ns = $runner.namespace }}
+{{- else if hasKey $runnerConfig "namespace" }}
+  {{- $ns = $runnerConfig.namespace }}
 {{- else if hasKey .Values "namespace" }}
   {{- $ns = .Values.namespace }}
 {{- end }}

--- a/charts/csghub/Chart.lock
+++ b/charts/csghub/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.2
+  version: 0.2.3
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
@@ -35,5 +35,5 @@ dependencies:
 - name: superset
   repository: https://charts.opencsg.com/infra
   version: 0.20.0
-digest: sha256:f51bfc6e1b87188cf91b8bb8c91e905418fd38ea20c4399996b690e64e6aeaa0
-generated: "2026-08-11T17:52:08.627218+08:00"
+digest: sha256:203b1fd8d76d46af035a9c73e8d4543ff5051c6b1d9dff11af9d0685ed836241
+generated: "2026-08-12T12:05:12.117412+08:00"

--- a/charts/csghub/Chart.yaml
+++ b/charts/csghub/Chart.yaml
@@ -33,7 +33,7 @@ appVersion: v2.4.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.2
+    version: 0.2.3
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/csgship/Chart.lock
+++ b/charts/csgship/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.2
+  version: 0.2.3
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
   version: 1.7.5
-digest: sha256:1e8710e757abeaa663d382c95d510a57b7a1d4610c550dcca4b89e6a730d9797
-generated: "2026-07-09T16:49:02.326857+08:00"
+digest: sha256:cd99070569219378eba37a6c486bf9777bcd9babd6ea88281f6edf1eb9019e5a
+generated: "2026-08-12T12:05:41.068706+08:00"

--- a/charts/csgship/Chart.yaml
+++ b/charts/csgship/Chart.yaml
@@ -33,7 +33,7 @@ appVersion: v0.4.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.2
+    version: 0.2.3
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/dataflow/Chart.lock
+++ b/charts/dataflow/Chart.lock
@@ -1,12 +1,12 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.2
+  version: 0.2.3
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
 - name: gateway-helm
   repository: oci://docker.io/envoyproxy
   version: 1.7.5
-digest: sha256:1e8710e757abeaa663d382c95d510a57b7a1d4610c550dcca4b89e6a730d9797
-generated: "2026-07-09T16:48:45.839133+08:00"
+digest: sha256:cd99070569219378eba37a6c486bf9777bcd9babd6ea88281f6edf1eb9019e5a
+generated: "2026-08-12T12:06:28.478978+08:00"

--- a/charts/dataflow/Chart.yaml
+++ b/charts/dataflow/Chart.yaml
@@ -33,7 +33,7 @@ appVersion: v2.4.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.2
+    version: 0.2.3
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14

--- a/charts/runner/Chart.lock
+++ b/charts/runner/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: common
   repository: https://charts.opencsg.com/csghub
-  version: 0.2.2
+  version: 0.2.3
 - name: reloader
   repository: https://charts.opencsg.com/infra
   version: 2.2.14
@@ -26,5 +26,5 @@ dependencies:
 - name: agent-sandbox
   repository: https://charts.opencsg.com/csghub
   version: 0.2.1
-digest: sha256:1ad97dc7e1141dcad665c3d340c3a744f125bb31868a8d2496a0472e673f6d1a
-generated: "2026-07-13T12:16:59.10153+08:00"
+digest: sha256:3bc7c36f9886159ae3618313dd54dfa7b73e6df37f92fffca0beb320cf546cc2
+generated: "2026-08-12T12:06:00.513345+08:00"

--- a/charts/runner/Chart.yaml
+++ b/charts/runner/Chart.yaml
@@ -36,7 +36,7 @@ appVersion: v2.4.0
 # Defined dependencies for subChart
 dependencies:
   - name: common
-    version: 0.2.2
+    version: 0.2.3
     repository: https://charts.opencsg.com/csghub
   - name: reloader
     version: 2.2.14


### PR DESCRIPTION
## Summary

Two related changes to the `common` chart and its dependents:

1. **`common/_namespace.tpl`** — `common.namespace` only read `mergingNamespace`/`namespace` from `.Values.runner`, which breaks when `common` is used as a subchart under an umbrella parent that nests the runner config under `.Values.runner.runner`. Added a fallback to the nested `runner.runner` config so the template works in both standalone and umbrella contexts.

2. **Bump `common` to `0.2.3`** — the `_namespace.tpl` fix ships in a new chart version. All charts that depend on `common` were updated from `0.2.2` → `0.2.3`:
   - `agent-sandbox`
   - `agentichub`
   - `csghub`
   - `csgship`
   - `dataflow`
   - `runner`

   Each `Chart.lock` was regenerated with the correct digest for the updated dependency.

## Verification

- All 6 dependent charts' `Chart.lock` digests recomputed and verified against the stored digest (helm `hashReq` semantics).
- `ct lint` passes for all charts (`common`, `runner`, `agent-sandbox`, `agentichub`, `csghub`, `csgship`, `dataflow`, `dataflow`).