### PR TITLE
fix(csghub): fix gitlab-shell ssh routing

### DIFF
--- a/charts/csghub/templates/gitlab-shell/service.yaml
+++ b/charts/csghub/templates/gitlab-shell/service.yaml
@@ -8,7 +8,7 @@ SPDX-License-Identifier: APACHE-2.0
 apiVersion: v1
 kind: Service
 metadata:
-  name: "csghub-gitlab-shell"
+  name: {{ $serviceName }}
   namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/service: {{ $service.name }}

--- a/charts/csghub/templates/gitlab-shell/tcproutes.yaml
+++ b/charts/csghub/templates/gitlab-shell/tcproutes.yaml
@@ -20,7 +20,7 @@ metadata:
 spec:
   parentRefs:
     - name: listeners
-      sectionName: git-ssh
+      sectionName: gitssh
   rules:
     - backendRefs:
         - name: {{ $serviceName }}


### PR DESCRIPTION
## Summary

Two bugs in the gitlab-shell SSH routing. Together they meant the SSH route could break entirely when the release name wasn't `csghub` (or `.Values.gitlabShell.name` was overridden).

### 1. Service name hardcoded — `templates/gitlab-shell/service.yaml`

```diff
-  name: "csghub-gitlab-shell"
+  name: {{ $serviceName }}
```

The Service `metadata.name` was a hardcoded literal, while every other resource (TCPRoute backendRef, Deployment, Job, ConfigMap, RBAC) derives the name via `common.service "gitlabShell"` + `common.names.custom` (`<release>-<gitlabShell.name>`). With a non-`csghub` release name (or a `.Values.gitlabShell.name` override) the Service name no longer matched the TCPRoute backendRef → SSH routing silently broke.

### 2. TCPRoute `sectionName` mismatch — `templates/gitlab-shell/tcproutes.yaml`

```diff
-      sectionName: git-ssh
+      sectionName: gitssh
```

The Gateway listener (`templates/gateway.yaml`) is named `gitssh`, but the TCPRoute targeted `sectionName: git-ssh`. A TCPRoute's `sectionName` must exactly match the listener name to attach — so the SSH route never attached, regardless of release name.

## Verification

Rendered with both default and override values:

| Scenario | Service | TCPRoute backendRef | sectionName ↔ listener |
|---|---|---|---|
| default (`csghub`) | `csghub-gitlab-shell` | `csghub-gitlab-shell` ✓ | `gitssh` ↔ `gitssh` ✓ |
| `mydep` + `gitlabShell.name=custom` | `mydep-custom` | `mydep-custom` ✓ | `gitssh` ↔ `gitssh` ✓ |

- Full chart renders clean (exit 0).
- Existing unit test expectations (`gitlab_shell_test.yaml`, release `csghub` + `name: gitlab-shell`) remain valid.