### PR TITLE
fix(runner): default docker registry from externalUrl to fix nil

### DIFF
--- a/charts/runner/templates/_runner.tpl
+++ b/charts/runner/templates/_runner.tpl
@@ -44,12 +44,20 @@ Returns:
   {{- $service := .service }}
   {{- $isBuiltIn := $ctx.Values.global.chartContext.isBuiltIn }}
 
-  {{- $registry := $service.registry }}
-  {{- if $isBuiltIn }}
-    {{- $registry = include "common.registry.config" (dict "ctx" $ctx "service" $service) | fromYaml }}
+  {{- $regRegistry := dig "registry" "registry" "" $service }}
+  {{- $regRepository := dig "registry" "repository" "" $service }}
+  {{- if not $regRegistry }}
+    {{- if $isBuiltIn }}
+      {{- $regRegistry = (include "common.registry.config" (dict "ctx" $ctx "service" $service) | fromYaml).registry }}
+    {{- else }}
+      {{- $regRegistry = $service.externalUrl | default "" | trimPrefix "https://" | trimPrefix "http://" }}
+    {{- end }}
+  {{- end }}
+  {{- if not $regRepository }}
+    {{- $regRepository = $ctx.Release.Namespace }}
   {{- end }}
 
-  {{- $kanikoCache := printf "--cache-repo=%s/%s" $registry.registry $registry.repository }}
+  {{- $kanikoCache := printf "--cache-repo=%s/%s" $regRegistry $regRepository }}
   {{- $args := list "--compressed-caching=true" "--single-snapshot" "--log-format=text" }}
   {{- $args = concat $args (list "--cache=true" "--cache-ttl=24h" $kanikoCache) }}
 

--- a/charts/runner/templates/configmap.yaml
+++ b/charts/runner/templates/configmap.yaml
@@ -64,12 +64,19 @@ data:
   STARHUB_SERVER_INTERNAL_ROOT_DOMAIN: {{ printf "%s.app.internal" (include "namespace.spaces" .) | quote }}
 
   ## Runner Configuration for Kaniko
-  {{- $dockerRegBase := printf "%s/%s/" $service.registry.registry $service.registry.repository }}
-  {{- if $isBuiltIn }}
-    {{- $runnerRegistry := include "common.registry.config" (dict "ctx" . "service" $service) | fromYaml }}
-    {{- $dockerRegBase = printf "%s/%s/" $runnerRegistry.registry $runnerRegistry.repository }}
+  {{- $regRegistry := dig "registry" "registry" "" $service }}
+  {{- $regRepository := dig "registry" "repository" "" $service }}
+  {{- if not $regRegistry }}
+    {{- if $isBuiltIn }}
+      {{- $regRegistry = (include "common.registry.config" (dict "ctx" . "service" $service) | fromYaml).registry }}
+    {{- else }}
+      {{- $regRegistry = $service.externalUrl | default "" | trimPrefix "https://" | trimPrefix "http://" }}
+    {{- end }}
   {{- end }}
-  STARHUB_SERVER_DOCKER_REG_BASE: {{ $dockerRegBase | quote }}
+  {{- if not $regRepository }}
+    {{- $regRepository = .Release.Namespace }}
+  {{- end }}
+  STARHUB_SERVER_DOCKER_REG_BASE: {{ printf "%s/%s/" $regRegistry $regRepository | quote }}
   STARHUB_SERVER_DOCKER_IMAGE_PULL_SECRET: {{ include "common.names.custom" (list . "docker-credential") | quote }}
   ## Runner Configuration for space-runtime
   STARHUB_SERVER_RUNNER_PUBLIC_DOCKER_REG_BASE: {{ or .Values.global.image.registry "docker.io" | quote }}


### PR DESCRIPTION
## Summary

`STARHUB_SERVER_DOCKER_REG_BASE` and the kaniko `--cache-repo` arg rendered `%!s(<nil>)/%!s(<nil>)/` in **standalone** mode because `runner.registry` defaults to `{}` and both fields were read unguarded.

## Root cause

- `configmap.yaml` built `$dockerRegBase` directly from `$service.registry.registry` / `.repository` — nil in standalone mode (only the bundled `isBuiltIn=true` path went through `common.registry.config`).
- `_runner.tpl` (`runner.kaniko.args`) had the same unguarded read for `--cache-repo`.

## Fix

Resolve registry/repository with a single priority, independent of deployment mode:

1. **`runner.registry.*`** — if set, always wins (works in both built-in and standalone).
2. Otherwise default from the deployment context:
   - **built-in**: csghub endpoint via `common.registry.config` (unchanged behavior)
   - **standalone**: `externalUrl` hostname
   - **repository**: falls back to `.Release.Namespace`

The `isBuiltIn` flag only decides which *default source* to use — it no longer overrides an explicit `runner.registry`.

## Verification (standalone render)

| Scenario | `STARHUB_SERVER_DOCKER_REG_BASE` | kaniko `--cache-repo` |
|---|---|---|
| default | `csghub.example.com/default/` | `csghub.example.com/default` |
| explicit `registry.registry/repository` | `reg.example.com/teamA/` | `reg.example.com/teamA` |
| custom `externalUrl` | `hub.mydomain.io/default/` | — |
| custom namespace | `csghub.example.com/myns/` | — |

- Both keys clean of `%!s(<nil>)`, full chart renders (exit 0).

> Note: bundled (`isBuiltIn=true`) mode cannot be rendered standalone in this repo (pre-existing `common.endpoint.minio` not defined — the known subchart-reverses-dependency issue). The registry priority logic is shared with standalone, so behavior is equivalent by construction.