### PR TITLE
fix(csghub): align portal/payment container ports and gate minio route

### DIFF
--- a/charts/csghub/templates/csghub/accounting/service.yaml
+++ b/charts/csghub/templates/csghub/accounting/service.yaml
@@ -22,8 +22,8 @@ spec:
       protocol: {{ dig "service" "protocol" "TCP" $service }}
       name: {{ $service.name }}
     {{- if eq .Values.global.edition "saas" }}
-    - port: {{ dig "service" "port" 8090 $paymentSvc }}
-      targetPort: 8090
+    - port: {{ dig "service" "port" 8094 $paymentSvc }}
+      targetPort: 8094
       protocol: {{ dig "service" "protocol" "TCP" $paymentSvc }}
       name: {{ $paymentSvc.name }}
     {{- end }}

--- a/charts/csghub/templates/csghub/portal/deployment.yaml
+++ b/charts/csghub/templates/csghub/portal/deployment.yaml
@@ -74,7 +74,7 @@ spec:
               ./csghub-portal db seed && \
               ./csghub-portal start server
           ports:
-            - containerPort: 8095
+            - containerPort: 8090
               name: {{ dig "service" "name" $service.name $service }}
               protocol: {{ dig "service" "protocol" "TCP" $service }}
           envFrom:

--- a/charts/csghub/templates/minio/httproutes.yaml
+++ b/charts/csghub/templates/minio/httproutes.yaml
@@ -3,6 +3,7 @@ Copyright OpenCSG, Inc. All Rights Reserved.
 SPDX-License-Identifier: APACHE-2.0
 */ -}}
 
+{{- if .Values.global.objectStore.enabled }}
 {{- $service := include "common.service" (dict "ctx" . "service" "minio") | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
 apiVersion: gateway.networking.k8s.io/v1
@@ -69,3 +70,4 @@ spec:
         - name: {{ $serviceName }}
           port: {{ dig "console" "service" "port" "9001" $service }}
     {{- end }}
+{{- end }}


### PR DESCRIPTION
## Summary

Three related fixes in the `csghub` chart addressing port mismatches and a missing feature gate.

### 1. portal container port alignment — `templates/csghub/portal/deployment.yaml`

```diff
-            - containerPort: 8095
+            - containerPort: 8090
```

The portal container listened on port `8095`, but the Service and probes target `8090`. The containerPort now matches the Service port, so probes and routing hit the actual listening port.

### 2. payment port alignment — `templates/csghub/accounting/service.yaml`

```diff
-    - port: {{ dig "service" "port" 8090 $paymentSvc }}
-      targetPort: 8090
+    - port: {{ dig "service" "port" 8094 $paymentSvc }}
+      targetPort: 8094
```

The `saas`-edition payment port on the accounting Service used hardcoded `8090`, while the payment container listens on `8094`. Now derived from `service.port` with the correct `8094` default and a matching `targetPort`.

### 3. minio HTTPRoute gating — `templates/minio/httproutes.yaml`

```diff
+{{- if .Values.global.objectStore.enabled }}
 ...
+{{- end }}
```

The minio HTTPRoute was rendered unconditionally. When using an external object store (`global.objectStore.enabled: false`), it still created routes pointing to the internal minio. The whole resource is now gated so external object storage produces no internal-minio routes.

## Verification

- Full `csghub` chart renders clean (exit 0).
- `helm unittest`: csghub 121/121 pass.