### PR TITLE
fix(agentichub): decouple langflow port, gate memmachine

### DIFF
--- a/charts/agentichub/templates/agenticflow/configmap.yaml
+++ b/charts/agentichub/templates/agenticflow/configmap.yaml
@@ -67,8 +67,8 @@ data:
   LANGFLOW_COOKIE_DOMAIN: {{ include "domain.base" . }}
   LANGFLOW_ACCESS_HTTPONLY: "false"
   LANGFLOW_REFRESH_HTTPONLY: "false"
-  LANGFLOW_WORKERS: "2"
-  LANGFLOW_PORT: {{ dig "service" "port" 7860 $service | quote }}
+  LANGFLOW_WORKERS: {{ dig "workers" "2" $service | quote }}
+  LANGFLOW_PORT: "7860"
   LANGFLOW_LOG_LEVEL: "info"
   LANGFLOW_SECRET_KEY: {{ $agenticflowToken | quote }}
   LANGFLOW_CACHE_TYPE: "async"

--- a/charts/agentichub/templates/csgbot/configmap.yaml
+++ b/charts/agentichub/templates/csgbot/configmap.yaml
@@ -96,9 +96,11 @@ data:
     [integrations]
     notifications-enabled = {{ dig "config" "integrations" "notification" "enabled" false .Values.csgbot | quote }}
     notification-endpoint = {{ printf "%s/api/v1/notifications?current_user=csgbot" $csghubEndpoint | quote }}
+    {{- if .Values.memmachine.enabled }}
     {{- $memSvc := include "common.service" (dict "ctx" . "service" "memmachine") | fromYaml }}
     {{- $memsSvcName := include "common.names.custom" (list . $memSvc.name) }}
     memmachine-endpoint = {{ printf "http://%s:8080/mcp/" $memsSvcName | quote }}
+    {{- end }}
     file-server-endpoint = {{ dig "config" "fileServer" "endpoint" "" .Values.csgbot | quote }}
 
     [observability]

--- a/charts/agentichub/values.yaml
+++ b/charts/agentichub/values.yaml
@@ -127,6 +127,9 @@ agenticflow:
     pullPolicy: "IfNotPresent"
     pullSecrets: []
 
+  ## Number of Langflow workers
+  workers: 2
+
   ## Service configuration
   service: {}
     # port: 7860


### PR DESCRIPTION
## Summary

Two fixes in the `agentichub` chart.

### 1. Decouple Langflow port + configurable workers — `templates/agenticflow/configmap.yaml`

```diff
-  LANGFLOW_WORKERS: "2"
-  LANGFLOW_PORT: {{ dig "service" "port" 7860 $service | quote }}
+  LANGFLOW_WORKERS: {{ dig "workers" "2" $service | quote }}
+  LANGFLOW_PORT: "7860"
```

- **`LANGFLOW_PORT`**: was coupled to `service.port`, so changing the exposed Service port also changed the container's listen port — but the hardcoded `containerPort`/probes still target `7860`, so they drifted (probes fail, Service `targetPort` misses). It is now a fixed `7860`; `service.port` only controls the Service.
- **`LANGFLOW_WORKERS`**: was hardcoded to `"2"`. Now configurable via a new `agenticflow.workers` value (default `2`), added to `values.yaml`.

### 2. Gate memmachine endpoint — `templates/csgbot/configmap.yaml`

```diff
+    {{- if .Values.memmachine.enabled }}
     {{- $memSvc := include "common.service" (dict "ctx" . "service" "memmachine") | fromYaml }}
     {{- $memsSvcName := include "common.names.custom" (list . $memSvc.name) }}
     memmachine-endpoint = {{ printf "http://%s:8080/mcp/" $memsSvcName | quote }}
+    {{- end }}
```

The `memmachine-endpoint` was emitted unconditionally even though `memmachine` is disabled by default (`memmachine.enabled: false`, and the subchart is gated by `condition: memmachine.enabled`). Now the endpoint is only rendered when memmachine is enabled, so a disabled subchart no longer leaves a dangling endpoint reference in the csgbot config.

## Verification

- Default render: `LANGFLOW_WORKERS: "2"`, no `memmachine-endpoint` line.
- `--set agenticflow.workers=8` → `LANGFLOW_WORKERS: "8"`.
- `--set memmachine.enabled=true` → `memmachine-endpoint: "http://t-memmachine:8080/mcp/"`.
- `helm template` exit 0; agentichub `helm unittest` 2/2 pass.