### PR TITLE
test(runner): refactor unittest, one suite per template, 145 tests

### DIFF
--- a/charts/runner/tests/configmap_test.yaml
+++ b/charts/runner/tests/configmap_test.yaml
@@ -1,195 +1,73 @@
+# Test suite for the runner ConfigMap.
+#
+# Baseline values come from tests/values.yaml (standalone mode, isBuiltIn=false).
+# Every assertion targets explicitly defined values or template fallbacks,
+# so editing default values in values.yaml cannot break this suite.
+#
+# NOTE: The isBuiltIn=true branch of configmap.yaml calls common.s3.config,
+# which depends on "common.endpoint.minio" defined only in the csghub umbrella
+# chart. It cannot be rendered by the standalone runner chart, so all
+# isBuiltIn-specific keys are not covered here.
+
 suite: Test Runner ConfigMap
 templates:
   - configmap.yaml
 release:
   name: csghub
   namespace: csghub
-set:
-  ## Global Definition
-  global:
-    ## Gateway Definition
-    gateway:
-      ## Controller
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-      service:
-        type: LoadBalancer
-        nodePort: {}
-
-      ## Access Domain
-      external:
-        domain: csghub.unittest.io
-        public: ""
-        useTop: false
-
-      ## TLS Encryption
-      tls:
-        enabled: false
-        secretName: ""
-
-    ## Image Definition
-    image:
-      registry: unittest.io
-      registryPolicy: default
-      tag: v2.0.0
-      pullPolicy: IfNotPresent
-      pullSecrets: []
-
-    ## Registry Definition
-    registry:
-      enabled: false
-
-    ## objectStore Definition
-    objectStore:
-      enabled: false
-
-    ## chartContext Definition
-    chartContext:
-      isBuiltIn: false
-
-  ## Csghub Definition
-  externalUrl: https://csghub.unittest.io
-  image:
-    repository: opencsghq/csghub-server
-    tag: v2.0.0
-    pullPolicy: IfNotPresent
-    pullSecrets: []
-  gateway:
-    enabled: true
-    tls: {}
-  hubAPIToken: unittest-api-token-standalone
-  originClusterID: unittest-cluster
-
-  ## Runner Definition
-  name: runner-unittest
-
-  service:
-    type: ClusterIP
-    port: 8082
-    protocol: TCP
-
-  runner:
-    region: es-west-1
-    interval: 30
-    namespace: spaces
-    mergingNamespace: disable
-    imageBuilderGitImage: ""
-    imageBuilderKanikoImage: ""
-    imageBuilderStatusTTL: 300
-    imageBuilderKanikoArgs: []
-    hearBeatIntervalInSec: 120
-    applicationEndpoint: http://kourier-internal.knative-serving.svc.cluster.local
-    networkInterface: eth0
-    storageClassName: local-path
-
-  model:
-    deployTimeoutInMin: 60
-    downloadEndpoint: "https://hub.opencsg.com"
-    dockerRegBase: model.unittest.io
-    deployStatusCheckInterval: 10
-
-  space:
-    usePublicDomain: true
-    pipIndexUrl: https://pypi.tuna.tsinghua.edu.cn/simple/
-    deployTimeoutInMin: 30
-    buildTimeoutInMin: 30
-    gpuModelLabel:
-      typeLabel: nvidia.com/gpu.product
-      capacityLabel: nvidia.com/gpu
-    readinessDelaySeconds: 120
-    readinessPeriodSeconds: 10
-    readinessFailureThreshold: 3
-    statusCheckInterval: 10
-
-  knative:
-    serving:
-      domain: unittest.io
-
-      autoscaler:
-        enableScaleToZero: true
-        scaleToZeroPodRetentionPeriod: 30m
-
-  rbac:
-    create: true
-    serviceAccountName: runner-unittest
-
-  logcollector:
-    enabled: false
-
-    loki:
-      address: ""
-
-  tempo:
-    address: ""
-
-  registry:
-    registry: registry.unittest.io
-    repository: csghub
-    username: unittest
-    password: unittest
-    insecure: "true"
-
-  objectStore:
-    endpoint: https://s3.unittest.io
-    accessKey: unittest
-    secretKey: unittest
-    bucket: runner-unittest
-    region: cn-north-1
-    secure: "true"
-    encrypt: "false"
-    pathStyle: "true"
-
-  prometheus:
-    enabled: true
-    gateway:
-      enabled: false
-      basicAuth: {}
-    server:
-      remoteWrite: []
-
-  volcano:
-    enabled: true
-    basic:
-      image_pull_policy: IfNotPresent
-
+values:
+  - values.yaml
 tests:
-  - it: Should render ConfigMap metadata normally
+  ## ------------------------------------------------------------------
+  ## Metadata
+  ## ------------------------------------------------------------------
+  - it: renders ConfigMap metadata with standard labels
     asserts:
       - equal:
           path: metadata.name
-          value: "csghub-runner-unittest"
+          value: "csghub-runner"
       - equal:
           path: metadata.namespace
           value: "csghub"
       - equal:
           path: metadata.labels["app.kubernetes.io/service"]
-          value: runner-unittest
+          value: "runner"
       - equal:
           path: metadata.labels["app.kubernetes.io/instance"]
-          value: csghub
+          value: "csghub"
       - equal:
           path: metadata.labels["app.kubernetes.io/name"]
-          value: runner
+          value: "runner"
       - equal:
           path: metadata.labels["app.kubernetes.io/managed-by"]
-          value: Helm
+          value: "Helm"
 
-  - it: Should render ConfigMap data with isBuiltIn=false normally
+  ## ------------------------------------------------------------------
+  ## Server configuration
+  ## ------------------------------------------------------------------
+  - it: renders server connection settings in standalone mode
     asserts:
       - equal:
           path: data.STARHUB_SERVER_API_TOKEN
-          value: "unittest-api-token-standalone"
+          value: "test-hub-api-token"
       - equal:
           path: data.STARHUB_SERVER_RUNNER_WEBHOOK_ENDPOINT
-          value: "https://csghub.unittest.io"
+          value: "https://csghub.example.com"
       - equal:
           path: data.STARHUB_SERVER_RUNNER_PUBLIC_DOMAIN
-          value: "http://runner-unittest.unittest.io"
+          value: "http://runner.example.com"
       - equal:
           path: data.STARHUB_SERVER_RUNNER_WATCH_CONFIGMAP_NAME
-          value: "csghub-runner-unittest"
+          value: "csghub-runner"
       - equal:
           path: data.STARHUB_SERVER_LOGCOLLECTOR_LOKI_URL
           value: ""
+
+  ## ------------------------------------------------------------------
+  ## Cluster configuration
+  ## ------------------------------------------------------------------
+  - it: renders cluster namespace and region settings
+    asserts:
       - equal:
           path: data.STARHUB_SERVER_CLUSTER_SPACES_NAMESPACE
           value: "spaces"
@@ -201,76 +79,158 @@ tests:
           value: "30"
       - equal:
           path: data.STARHUB_SERVER_CLUSTER_REGION
-          value: "es-west-1"
+          value: "test-region"
+      - equal:
+          path: data.STARHUB_SERVER_CLUSTER_ALLOW_CPU_RESOURCE_SCHEDULE_TO_GPU_NODE
+          value: "false"
+
+  ## ------------------------------------------------------------------
+  ## Root domain configuration
+  ## ------------------------------------------------------------------
+  - it: renders public root domain derived from the gateway external domain
+    asserts:
       - equal:
           path: data.STARHUB_SERVER_PUBLIC_ROOT_DOMAIN
-          value: "csghub.unittest.io"
+          value: "csghub.example.com"
       - equal:
           path: data.STARHUB_SERVER_INTERNAL_ROOT_DOMAIN
           value: "spaces.app.internal"
+
+  - it: leaves public root domain empty when usePublicDomain is false
+    set:
+      space:
+        usePublicDomain: false
+    asserts:
+      - equal:
+          path: data.STARHUB_SERVER_PUBLIC_ROOT_DOMAIN
+          value: ""
+
+  - it: keeps the full subdomain when useTop is true on a multi-level domain
+    set:
+      global:
+        gateway:
+          external:
+            useTop: true
+    asserts:
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_PUBLIC_DOMAIN
+          value: "http://runner.csghub.example.com"
+
+  - it: prefixes a second-level domain with csghub for the public root domain
+    set:
+      global:
+        gateway:
+          external:
+            domain: "example.com"
+    asserts:
+      - equal:
+          path: data.STARHUB_SERVER_PUBLIC_ROOT_DOMAIN
+          value: "csghub.example.com"
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_PUBLIC_DOMAIN
+          value: "http://runner.example.com"
+
+  ## ------------------------------------------------------------------
+  ## Registry and image builder configuration
+  ## ------------------------------------------------------------------
+  - it: renders registry and image builder settings from explicit values
+    asserts:
       - equal:
           path: data.STARHUB_SERVER_DOCKER_REG_BASE
-          value: "registry.unittest.io/csghub/"
+          value: "registry.example.com/csghub/"
       - equal:
           path: data.STARHUB_SERVER_DOCKER_IMAGE_PULL_SECRET
           value: "csghub-docker-credential"
       - equal:
           path: data.STARHUB_SERVER_RUNNER_PUBLIC_DOCKER_REG_BASE
-          value: "unittest.io"
+          value: "docker.io"
       - equal:
           path: data.STARHUB_SERVER_SPACE_PYPI_INDEX_URL
-          value: "https://pypi.tuna.tsinghua.edu.cn/simple/"
+          value: "https://pypi.example.com/simple"
       - equal:
           path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_GIT_IMAGE
-          value: "unittest.io/opencsghq/git:2.52.0"
+          value: "docker.io/opencsghq/git:2.52.0"
       - equal:
           path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_IMAGE
-          value: "unittest.io/opencsghq/kaniko-executor:v1.24.0"
+          value: "docker.io/opencsghq/kaniko-executor:v1.24.0"
       - equal:
           path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_JOB_TTL
           value: "300"
       - equal:
           path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_STATUS_TTL
           value: "300"
-      - matchRegex:
-          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_ARGS
-          pattern: '--cache-repo=registry.unittest.io/csghub'
+
+  - it: keeps the kaniko job TTL fixed while the status TTL is overridden
+    set:
+      runner:
+        imageBuilderStatusTTL: 999
+    asserts:
       - equal:
-          path: data.STARHUB_SERVER_ARGO_SERVICE_ACCOUNT
-          value: "csghub-argo-workflow-executor"
+          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_JOB_TTL
+          value: "300"
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_STATUS_TTL
+          value: "999"
+
+  - it: derives the docker registry base from externalUrl when registry is empty
+    set:
+      registry:
+        registry: ""
+    asserts:
+      - equal:
+          path: data.STARHUB_SERVER_DOCKER_REG_BASE
+          value: "csghub.example.com/csghub/"
+
+  - it: builds kaniko args from registry, pip and hf endpoint
+    asserts:
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_ARGS
+          value: "--compressed-caching=true,--single-snapshot,--log-format=text,--cache=true,--cache-ttl=24h,--cache-repo=registry.example.com/csghub,--build-arg=PyPI=https://pypi.example.com/simple,--build-arg=HF_ENDPOINT=https://csghub.example.com/hf"
+
+  - it: appends skip-tls and extra args when registry insecure and extra args are set
+    set:
+      registry:
+        insecure: "true"
+      runner:
+        imageBuilderKanikoArgs:
+          - "--custom-arg=x"
+        imageBuilderGitImage: "git.example.com/git:9.9"
+        imageBuilderKanikoImage: "kaniko.example.com/kaniko:9.9"
+        imageBuilderStatusTTL: 999
+    asserts:
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_GIT_IMAGE
+          value: "git.example.com/git:9.9"
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_IMAGE
+          value: "kaniko.example.com/kaniko:9.9"
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_STATUS_TTL
+          value: "999"
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_ARGS
+          value: "--compressed-caching=true,--single-snapshot,--log-format=text,--cache=true,--cache-ttl=24h,--cache-repo=registry.example.com/csghub,--build-arg=PyPI=https://pypi.example.com/simple,--build-arg=HF_ENDPOINT=https://csghub.example.com/hf,--skip-tls-verify,--skip-tls-verify-pull,--insecure,--insecure-pull,--custom-arg=x"
+
+  ## ------------------------------------------------------------------
+  ## Argo and GPU labels
+  ## ------------------------------------------------------------------
+  - it: renders argo service account and gpu model label
+    asserts:
       - equal:
           path: data.STARHUB_SERVER_ARGO_SERVICE_ACCOUNT
           value: "csghub-argo-workflow-executor"
       - equal:
           path: data.STARHUB_SERVER_GPU_MODEL_LABEL
           value: '[{"type_label": "nvidia.com/gpu.product", "capacity_label": "nvidia.com/gpu"}]'
+
+  ## ------------------------------------------------------------------
+  ## Timeouts and readiness probes
+  ## ------------------------------------------------------------------
+  - it: renders model and space timeouts from explicit values
+    asserts:
       - equal:
           path: data.STARHUB_SERVER_MODEL_DEPLOY_TIMEOUT_IN_MINUTES
           value: "60"
-      - equal:
-          path: data.STARHUB_SERVER_MODEL_DOWNLOAD_ENDPOINT
-          value: "https://csghub.unittest.io"
-      - equal:
-          path: data.STARHUB_SERVER_MODEL_DOCKER_REG_BASE
-          value: "model.unittest.io"
-      - equal:
-          path: data.STARHUB_SERVER_MODEL_DEPLOY_STATUS_CHECK_INTERVAL
-          value: "10"
-      - equal:
-          path: data.STARHUB_SERVER_CLUSTER_ID
-          value: "unittest-cluster"
-      - equal:
-          path: data.STARHUB_SERVER_RUNNER_HEARTBEAT_INTERVAL_IN_SEC
-          value: "120"
-      - equal:
-          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_GIT_IMAGE
-          value: "unittest.io/opencsghq/git:2.52.0"
-      - equal:
-          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_KANIKO_IMAGE
-          value: "unittest.io/opencsghq/kaniko-executor:v1.24.0"
-      - equal:
-          path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_STATUS_TTL
-          value: "300"
       - equal:
           path: data.STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES
           value: "30"
@@ -289,21 +249,57 @@ tests:
       - equal:
           path: data.STARHUB_SERVER_READINESS_FAILURE_THRESHOLD
           value: "3"
+
+  ## ------------------------------------------------------------------
+  ## Model endpoint and docker registry
+  ## ------------------------------------------------------------------
+  - it: renders model download endpoint and docker registry base
+    asserts:
+      - equal:
+          path: data.STARHUB_SERVER_MODEL_DOWNLOAD_ENDPOINT
+          value: "https://csghub.example.com"
+      - equal:
+          path: data.STARHUB_SERVER_MODEL_DOCKER_REG_BASE
+          value: "docker.io"
+      - equal:
+          path: data.STARHUB_SERVER_MODEL_DEPLOY_STATUS_CHECK_INTERVAL
+          value: "10"
       - equal:
           path: data.STARHUB_SERVER_CLUSTER_ID
-          value: "unittest-cluster"
+          value: "test-cluster-id"
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_HEARTBEAT_INTERVAL_IN_SEC
+          value: "120"
+
+  - it: uses custom docker registry base when model.dockerRegBase is set
+    set:
+      model:
+        dockerRegBase: "model.example.com"
+    asserts:
+      - equal:
+          path: data.STARHUB_SERVER_MODEL_DOCKER_REG_BASE
+          value: "model.example.com"
+
+  ## ------------------------------------------------------------------
+  ## S3 / object store configuration
+  ## ------------------------------------------------------------------
+  - it: renders s3 connection settings from explicit values
+    asserts:
       - equal:
           path: data.STARHUB_SERVER_S3_ACCESS_KEY_ID
-          value: "unittest"
+          value: "test-access"
       - equal:
           path: data.STARHUB_SERVER_S3_ACCESS_KEY_SECRET
-          value: "unittest"
+          value: "test-secret"
       - equal:
           path: data.STARHUB_SERVER_S3_ENDPOINT
-          value: "s3.unittest.io"
+          value: "s3.example.com"
       - equal:
           path: data.STARHUB_SERVER_S3_BUCKET
-          value: "runner-unittest"
+          value: "test-bucket"
+      - equal:
+          path: data.STARHUB_SERVER_ARGO_S3_PUBLIC_BUCKET
+          value: "test-bucket"
       - equal:
           path: data.STARHUB_SERVER_S3_REGION
           value: "cn-north-1"
@@ -313,20 +309,117 @@ tests:
       - equal:
           path: data.STARHUB_SERVER_S3_BUCKET_LOOKUP
           value: "path"
+
+  - it: uses auto bucket lookup when pathStyle is not true
+    set:
+      objectStore:
+        pathStyle: "false"
+    asserts:
+      - equal:
+          path: data.STARHUB_SERVER_S3_BUCKET_LOOKUP
+          value: "auto"
+
+  ## ------------------------------------------------------------------
+  ## Tracing (standalone mode)
+  ## ------------------------------------------------------------------
+  - it: disables tracing logging when tempo address is empty
+    asserts:
       - equal:
           path: data.OPENCSG_TRACING_OTLP_LOGGING
           value: "false"
       - notExists:
           path: data.OPENCSG_TRACING_OTLP_ENDPOINT
+
+  - it: enables tracing when tempo address is set
+    set:
+      tempo:
+        address: "https://tempo.example.com"
+    asserts:
+      - equal:
+          path: data.OPENCSG_TRACING_OTLP_LOGGING
+          value: "true"
+      - equal:
+          path: data.OPENCSG_TRACING_OTLP_ENDPOINT
+          value: "https://tempo.example.com"
+
+  ## ------------------------------------------------------------------
+  ## Application endpoint resolution
+  ## ------------------------------------------------------------------
+  - it: derives envoy-knative endpoint in gateway-api mode with envoy controller
+    asserts:
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_APPLICATION_ENDPOINT
+          value: "http://csghub-envoy-knative.csghub.svc.cluster.local"
+
+  - it: derives kourier endpoint in kourier mode
+    set:
+      knative:
+        serving:
+          ingress: "kourier"
+    asserts:
       - equal:
           path: data.STARHUB_SERVER_RUNNER_APPLICATION_ENDPOINT
           value: "http://kourier-internal.knative-serving.svc.cluster.local"
+
+  - it: falls back to auto endpoint with a non-envoy gateway controller
+    set:
+      global:
+        gateway:
+          controllerName: "istio.io/gateway-controller"
+    asserts:
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_APPLICATION_ENDPOINT
+          value: "auto"
+
+  - it: uses the configured endpoint when applicationEndpoint is set
+    set:
+      runner:
+        applicationEndpoint: "http://custom.example.com:9999"
+    asserts:
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_APPLICATION_ENDPOINT
+          value: "http://custom.example.com:9999"
+
+  ## ------------------------------------------------------------------
+  ## LWS and storage
+  ## ------------------------------------------------------------------
+  - it: renders empty network interface and storage class by default
+    asserts:
       - equal:
           path: data.STARHUB_SERVER_RUNNER_NETWORK_INTERFACE
-          value: "eth0"
+          value: ""
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_STORAGE_CLASS
+          value: ""
+
+  - it: renders network interface and storage class when set
+    set:
+      runner:
+        networkInterface: "eth1"
+        storageClassName: "local-path"
+    asserts:
+      - equal:
+          path: data.STARHUB_SERVER_RUNNER_NETWORK_INTERFACE
+          value: "eth1"
       - equal:
           path: data.STARHUB_SERVER_RUNNER_STORAGE_CLASS
           value: "local-path"
+
+  ## ------------------------------------------------------------------
+  ## Volcano scheduler
+  ## ------------------------------------------------------------------
+  - it: omits volcano keys when volcano is disabled
+    asserts:
+      - notExists:
+          path: data.STARHUB_SERVER_RUNNER_KUBE_SCHEDULER
+      - notExists:
+          path: data.STARHUB_SERVER_RUNNER_VGPU_NODE_RESOURCE_NAME
+
+  - it: enables volcano scheduler keys when volcano is enabled
+    set:
+      volcano:
+        enabled: true
+    asserts:
       - equal:
           path: data.STARHUB_SERVER_RUNNER_KUBE_SCHEDULER
           value: "volcano"
@@ -343,7 +436,10 @@ tests:
           path: data.STARHUB_SERVER_RUNNER_VGPU_MEMORY_REQ_KEY
           value: "volcano.sh/vgpu-memory"
 
-  - it: Should render ConfigMap with gateway service type NodePort and TLS encryption normally
+  ## ------------------------------------------------------------------
+  ## Gateway-dependent keys
+  ## ------------------------------------------------------------------
+  - it: renders public domain with nodeport and tls ports when gateway is NodePort with TLS
     set:
       global:
         gateway:
@@ -355,29 +451,69 @@ tests:
               gitssh: 30022
           tls:
             enabled: true
-            secretName: unittest-tls
+            secretName: "test-tls"
     asserts:
       - equal:
           path: data.STARHUB_SERVER_RUNNER_PUBLIC_DOMAIN
-          value: "https://runner-unittest.unittest.io:30443"
+          value: "https://runner.example.com:30443"
 
-  - it: Should render ConfigMap with loki and tempo normally
+  - it: renders loki url when logcollector loki address is set
     set:
       logcollector:
         enabled: true
-
         loki:
-          address: https://loki.unittest.io
-
-      tempo:
-        address: https://tempo.unittest.io
+          address: "https://loki.example.com"
     asserts:
       - equal:
           path: data.STARHUB_SERVER_LOGCOLLECTOR_LOKI_URL
-          value: "https://loki.unittest.io"
+          value: "https://loki.example.com"
+
+  ## ------------------------------------------------------------------
+  ## Template fallback defaults (explicitly nulled via empty strings)
+  ## ------------------------------------------------------------------
+  - it: falls back to template defaults when values are empty
+    set:
+      runner:
+        region: ""
+        hearBeatIntervalInSec: ""
+      model:
+        deployTimeoutInMin: ""
+        deployStatusCheckInterval: ""
+      space:
+        deployTimeoutInMin: ""
+        buildTimeoutInMin: ""
+        statusCheckInterval: ""
+        readinessDelaySeconds: ""
+        readinessPeriodSeconds: ""
+        readinessFailureThreshold: ""
+    asserts:
       - equal:
-          path: data.OPENCSG_TRACING_OTLP_LOGGING
-          value: "true"
+          path: data.STARHUB_SERVER_CLUSTER_REGION
+          value: "region-0"
       - equal:
-          path: data.OPENCSG_TRACING_OTLP_ENDPOINT
-          value: "https://tempo.unittest.io"
+          path: data.STARHUB_SERVER_RUNNER_HEARTBEAT_INTERVAL_IN_SEC
+          value: "120"
+      - equal:
+          path: data.STARHUB_SERVER_MODEL_DEPLOY_TIMEOUT_IN_MINUTES
+          value: "60"
+      - equal:
+          path: data.STARHUB_SERVER_MODEL_DEPLOY_STATUS_CHECK_INTERVAL
+          value: "10"
+      - equal:
+          path: data.STARHUB_SERVER_SPACE_DEPLOY_TIMEOUT_IN_MINUTES
+          value: "30"
+      - equal:
+          path: data.STARHUB_SERVER_SPACE_BUILD_TIMEOUT_IN_MINUTES
+          value: "30"
+      - equal:
+          path: data.STARHUB_SERVER_SPACE_STATUS_CHECK_INTERVAL
+          value: "10"
+      - equal:
+          path: data.STARHUB_SERVER_READINESS_DELAY_SECONDS
+          value: "120"
+      - equal:
+          path: data.STARHUB_SERVER_READINESS_PERIOD_SECONDS
+          value: "10"
+      - equal:
+          path: data.STARHUB_SERVER_READINESS_FAILURE_THRESHOLD
+          value: "3"

--- a/charts/runner/tests/deployment_test.yaml
+++ b/charts/runner/tests/deployment_test.yaml
@@ -1,44 +1,643 @@
+# Test suite for the runner Deployment and logcollector Deployment.
+#
+# Baseline values come from tests/values.yaml. The main deployment renders in
+# all cases; the logcollector deployment renders only when logcollector.enabled
+# is true. isBuiltIn branches that call common.s3.config cannot be rendered by
+# the standalone runner chart and are intentionally not covered.
+
 suite: Test Runner Deployment
 templates:
   - deployment.yaml
   - deployment-logcollector.yaml
 release:
-  name: runner
+  name: csghub
   namespace: csghub
-set:
-  global:
-    image:
-      registry: "docker.io"
-      registryPolicy: "default"
-      tag: "v1.11.0"
-  image:
-    registry: "docker.io"
-    repository: "opencsghq/csghub-server"
-    tag: "v1.11.0"
-  rbac:
-    enabled: true
-    serviceAccountName: "csghub-runner"
-  logcollector:
-    enabled: true
-    loki:
-      address: "https://loki.example.cn"
+values:
+  - values.yaml
 tests:
-  - it: should render deployment correct when default
+  ## ------------------------------------------------------------------
+  ## Main deployment: default rendering
+  ## ------------------------------------------------------------------
+  - it: renders the main deployment metadata and labels
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "csghub-runner"
+      - equal:
+          path: metadata.namespace
+          value: "csghub"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/service"]
+          value: "runner"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: "csghub"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: "runner"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: "Helm"
+      - equal:
+          path: metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+
+  - it: renders the main deployment spec defaults
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 1
+      - equal:
+          path: spec.minReadySeconds
+          value: 30
+      - equal:
+          path: spec.progressDeadlineSeconds
+          value: 600
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/service"]
+          value: "runner"
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/service"]
+          value: "runner"
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/instance"]
+          value: "csghub"
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 20
+      - equal:
+          path: spec.template.spec.automountServiceAccountToken
+          value: true
+
+  - it: renders the runner container with image, command and probes
+    template: deployment.yaml
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: "runner"
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/opencsghq/csghub-server:v2.4.0-ee"
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "IfNotPresent"
+      - equal:
+          path: spec.template.spec.containers[0].command[0]
+          value: "/starhub-bin/starhub"
+      - equal:
+          path: spec.template.spec.containers[0].command[1]
+          value: "deploy"
+      - equal:
+          path: spec.template.spec.containers[0].command[2]
+          value: "runner"
+      - equal:
+          path: spec.template.spec.containers[0].command[4]
+          value: "info"
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8082
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: "runner"
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].protocol
+          value: "TCP"
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].configMapRef.name
+          value: "csghub-runner"
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: 8082
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.path
+          value: "/healthz"
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.scheme
+          value: "HTTP"
+
+  ## ------------------------------------------------------------------
+  ## Main deployment: service account
+  ## ------------------------------------------------------------------
+  - it: uses the default service account name when not overridden
+    template: deployment.yaml
     asserts:
       - equal:
           path: spec.template.spec.serviceAccountName
           value: "csghub-runner"
-      - equal:
-          path: spec.template.spec.containers[0].image
-          value: "docker.io/opencsghq/csghub-server:v1.11.0-ee"
 
-  - it: should render deployment correct when default
+  - it: uses the custom service account name when rbac.serviceAccountName is set
+    template: deployment.yaml
+    set:
+      rbac:
+        serviceAccountName: "custom-sa"
+    asserts:
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: "custom-sa"
+
+  ## ------------------------------------------------------------------
+  ## Main deployment: env and resources
+  ## ------------------------------------------------------------------
+  - it: renders container environment variables with quoted values
+    template: deployment.yaml
+    set:
+      environments:
+        DEBUG: "false"
+        MAX_WORKERS: "10"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].env[0].name
+          value: "DEBUG"
+      - equal:
+          path: spec.template.spec.containers[0].env[0].value
+          value: "false"
+      - equal:
+          path: spec.template.spec.containers[0].env[1].name
+          value: "MAX_WORKERS"
+      - equal:
+          path: spec.template.spec.containers[0].env[1].value
+          value: "10"
+
+  - it: renders container resources
+    template: deployment.yaml
+    set:
+      resources:
+        requests:
+          cpu: 250m
+          memory: 256Mi
+        limits:
+          cpu: 500m
+          memory: 512Mi
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.cpu
+          value: "250m"
+      - equal:
+          path: spec.template.spec.containers[0].resources.requests.memory
+          value: "256Mi"
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.cpu
+          value: "500m"
+      - equal:
+          path: spec.template.spec.containers[0].resources.limits.memory
+          value: "512Mi"
+
+  - it: omits resources block when not configured
+    template: deployment.yaml
+    asserts:
+      - notExists:
+          path: spec.template.spec.containers[0].resources
+
+  ## ------------------------------------------------------------------
+  ## Main deployment: pod metadata and scheduling
+  ## ------------------------------------------------------------------
+  - it: renders pod labels and pod annotations when set
+    template: deployment.yaml
+    set:
+      podLabels:
+        app.kubernetes.io/component: "runner"
+        environment: "production"
+      podAnnotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "9090"
+    asserts:
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/service"]
+          value: "runner"
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/component"]
+          value: "runner"
+      - equal:
+          path: spec.template.metadata.labels["environment"]
+          value: "production"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - equal:
+          path: spec.template.metadata.annotations["prometheus.io/port"]
+          value: "9090"
+
+  - it: renders nodeSelector, tolerations and affinity when set
+    template: deployment.yaml
+    set:
+      nodeSelector:
+        node-type: "compute-optimized"
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "csghub"
+          effect: "NoSchedule"
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchExpressions:
+                    - key: "app"
+                      operator: "In"
+                      values: ["runner"]
+                topologyKey: "kubernetes.io/hostname"
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector["node-type"]
+          value: "compute-optimized"
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: "dedicated"
+      - equal:
+          path: spec.template.spec.tolerations[0].operator
+          value: "Equal"
+      - equal:
+          path: spec.template.spec.tolerations[0].effect
+          value: "NoSchedule"
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].weight
+          value: 100
+      - equal:
+          path: spec.template.spec.affinity.podAntiAffinity.preferredDuringSchedulingIgnoredDuringExecution[0].podAffinityTerm.topologyKey
+          value: "kubernetes.io/hostname"
+
+  - it: renders pod and container security contexts when set
+    template: deployment.yaml
+    set:
+      podSecurityContext:
+        fsGroup: 2000
+        runAsNonRoot: true
+      securityContext:
+        capabilities:
+          drop: ["ALL"]
+        readOnlyRootFilesystem: true
+        runAsUser: 1000
+    asserts:
+      - equal:
+          path: spec.template.spec.securityContext.fsGroup
+          value: 2000
+      - equal:
+          path: spec.template.spec.securityContext.runAsNonRoot
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.readOnlyRootFilesystem
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].securityContext.runAsUser
+          value: 1000
+
+  ## ------------------------------------------------------------------
+  ## Main deployment: image configuration
+  ## ------------------------------------------------------------------
+  - it: overrides the image registry when registryPolicy is force
+    template: deployment.yaml
     set:
       global:
         image:
+          registryPolicy: force
           registry: "opencsg-registry.cn-beijing.cr.aliyuncs.com"
-          registryPolicy: "force"
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/csghub-server:v1.11.0-ee"
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/csghub-server:v2.4.0-ee"
+
+  - it: appends the ce edition suffix when global.edition is ce
+    template: deployment.yaml
+    set:
+      global:
+        edition: "ce"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/opencsghq/csghub-server:v2.4.0-ce"
+
+  - it: appends no suffix when global.edition is saas
+    template: deployment.yaml
+    set:
+      global:
+        edition: "saas"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/opencsghq/csghub-server:v2.4.0"
+
+  - it: uses the service-level image tag when image.tag is overridden
+    template: deployment.yaml
+    set:
+      image:
+        tag: "v9.9.9"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/opencsghq/csghub-server:v9.9.9-ee"
+
+  - it: renders imagePullSecrets from global pullSecrets
+    template: deployment.yaml
+    set:
+      global:
+        image:
+          pullSecrets:
+            - "regsecret"
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: "regsecret"
+
+  - it: prefers service-level pullSecrets over global pullSecrets
+    template: deployment.yaml
+    set:
+      image:
+        pullSecrets:
+          - "svc-secret"
+      global:
+        image:
+          pullSecrets:
+            - "global-secret"
+    asserts:
+      - equal:
+          path: spec.template.spec.imagePullSecrets[0].name
+          value: "svc-secret"
+
+  - it: prefers the service-level pull policy over the global pull policy
+    template: deployment.yaml
+    set:
+      image:
+        pullPolicy: "Always"
+      global:
+        image:
+          pullPolicy: "Never"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].imagePullPolicy
+          value: "Always"
+
+  ## ------------------------------------------------------------------
+  ## Main deployment: service-level label and selector overrides
+  ## ------------------------------------------------------------------
+  - it: replaces common labels with service-level labels when set
+    template: deployment.yaml
+    set:
+      labels:
+        foo: "bar"
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/service"]
+          value: "runner"
+      - equal:
+          path: metadata.labels["foo"]
+          value: "bar"
+      - notExists:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+      - notExists:
+          path: metadata.labels["app.kubernetes.io/instance"]
+
+  - it: replaces the common selector with service-level selector when set
+    template: deployment.yaml
+    set:
+      selector:
+        custom: "sel"
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/service"]
+          value: "runner"
+      - equal:
+          path: spec.selector.matchLabels["custom"]
+          value: "sel"
+      - notExists:
+          path: spec.selector.matchLabels["app.kubernetes.io/instance"]
+
+  - it: appends service-level annotations next to the reloader annotation
+    template: deployment.yaml
+    set:
+      annotations:
+        custom: "ann"
+    asserts:
+      - equal:
+          path: metadata.annotations["reloader.stakater.com/auto"]
+          value: "true"
+      - equal:
+          path: metadata.annotations["custom"]
+          value: "ann"
+
+  ## ------------------------------------------------------------------
+  ## Main deployment: spec overrides and optional container fields
+  ## ------------------------------------------------------------------
+  - it: renders overridden spec scalars when provided
+    template: deployment.yaml
+    set:
+      replicas: 3
+      minReadySeconds: 10
+      terminationGracePeriodSeconds: 60
+      revisionHistoryLimit: 5
+      progressDeadlineSeconds: 300
+    asserts:
+      - equal:
+          path: spec.replicas
+          value: 3
+      - equal:
+          path: spec.minReadySeconds
+          value: 10
+      - equal:
+          path: spec.template.spec.terminationGracePeriodSeconds
+          value: 60
+      - equal:
+          path: spec.revisionHistoryLimit
+          value: 5
+      - equal:
+          path: spec.progressDeadlineSeconds
+          value: 300
+
+  - it: renders the rolling update strategy when set
+    template: deployment.yaml
+    set:
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.strategy.type
+          value: "RollingUpdate"
+      - equal:
+          path: spec.strategy.rollingUpdate.maxUnavailable
+          value: 1
+
+  - it: renders the startup probe when set
+    template: deployment.yaml
+    set:
+      startupProbe:
+        exec:
+          command: ["ls"]
+        initialDelaySeconds: 5
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.exec.command[0]
+          value: "ls"
+      - equal:
+          path: spec.template.spec.containers[0].startupProbe.initialDelaySeconds
+          value: 5
+
+  - it: renders the lifecycle hook when set
+    template: deployment.yaml
+    set:
+      lifecycle:
+        preStop:
+          exec:
+            command: ["/bin/sh", "-c", "sleep 5"]
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[0]
+          value: "/bin/sh"
+      - equal:
+          path: spec.template.spec.containers[0].lifecycle.preStop.exec.command[2]
+          value: "sleep 5"
+
+  - it: renders stdin and tty when set
+    template: deployment.yaml
+    set:
+      stdin: true
+      tty: true
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].stdin
+          value: true
+      - equal:
+          path: spec.template.spec.containers[0].tty
+          value: true
+
+  - it: renders volumes and volumeMounts when set
+    template: deployment.yaml
+    set:
+      volumes:
+        - name: data
+          emptyDir: {}
+      volumeMounts:
+        - name: data
+          mountPath: /data
+    asserts:
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: "data"
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].name
+          value: "data"
+      - equal:
+          path: spec.template.spec.containers[0].volumeMounts[0].mountPath
+          value: "/data"
+
+  - it: renders topologySpreadConstraints when set
+    template: deployment.yaml
+    set:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "zone"
+          whenUnsatisfiable: "DoNotSchedule"
+          labelSelector:
+            matchLabels:
+              app: "runner"
+    asserts:
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].maxSkew
+          value: 1
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].topologyKey
+          value: "zone"
+      - equal:
+          path: spec.template.spec.topologySpreadConstraints[0].whenUnsatisfiable
+          value: "DoNotSchedule"
+
+  - it: renders hostname and subdomain when set
+    template: deployment.yaml
+    set:
+      hostname: "runner-host"
+      subdomain: "runner-svc"
+    asserts:
+      - equal:
+          path: spec.template.spec.hostname
+          value: "runner-host"
+      - equal:
+          path: spec.template.spec.subdomain
+          value: "runner-svc"
+
+  ## ------------------------------------------------------------------
+  ## Logcollector deployment
+  ## ------------------------------------------------------------------
+  - it: renders no logcollector deployment when disabled
+    template: deployment-logcollector.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the logcollector deployment when enabled
+    template: deployment-logcollector.yaml
+    set:
+      logcollector:
+        enabled: true
+        loki:
+          address: "https://loki.example.com"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "csghub-logcollector"
+      - equal:
+          path: metadata.namespace
+          value: "csghub"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/service"]
+          value: "logcollector"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: "runner"
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: "csghub-runner"
+
+  - it: renders the logcollector container with its own port
+    template: deployment-logcollector.yaml
+    set:
+      logcollector:
+        enabled: true
+        loki:
+          address: "https://loki.example.com"
+    asserts:
+      - equal:
+          path: spec.template.spec.containers[0].name
+          value: "logcollector"
+      - equal:
+          path: spec.template.spec.containers[0].image
+          value: "docker.io/opencsghq/csghub-server:v2.4.0-ee"
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].containerPort
+          value: 8096
+      - equal:
+          path: spec.template.spec.containers[0].ports[0].name
+          value: "logcollector"
+      - equal:
+          path: spec.template.spec.containers[0].envFrom[0].configMapRef.name
+          value: "csghub-runner"
+      - equal:
+          path: spec.template.spec.containers[0].livenessProbe.tcpSocket.port
+          value: 8096
+      - equal:
+          path: spec.template.spec.containers[0].readinessProbe.httpGet.port
+          value: 8096
+
+  - it: renders the wait-for-loki init container with the loki address
+    template: deployment-logcollector.yaml
+    set:
+      logcollector:
+        enabled: true
+        loki:
+          address: "https://loki.example.com"
+    asserts:
+      - equal:
+          path: spec.template.spec.initContainers[0].name
+          value: "wait-for-loki"
+      - equal:
+          path: spec.template.spec.initContainers[0].image
+          value: "docker.io/busybox:latest"
+      - equal:
+          path: spec.template.spec.initContainers[0].imagePullPolicy
+          value: "IfNotPresent"
+      - matchRegex:
+          path: spec.template.spec.initContainers[0].command[2]
+          pattern: 'https://loki\.example\.com/ready'

--- a/charts/runner/tests/gateway_test.yaml
+++ b/charts/runner/tests/gateway_test.yaml
@@ -1,253 +1,664 @@
+# Test suite for the runner Gateway resources.
+#
+# Covers gateway.yaml (GatewayClass, listeners, knative, knative-local),
+# envoy-proxy.yaml (main, knative, knative-local EnvoyProxy CRs),
+# envoy-proxy-metrics.yaml, httproutes.yaml and httproutes-redirect.yaml.
+#
+# Baseline is standalone mode (isBuiltIn=false) with gateway-api ingress and
+# an Envoy Gateway controller. Multi-document templates select the target
+# document by name via documentSelector instead of relying on fragile indexes.
+
 suite: Test Runner Gateway
 templates:
   - gateway.yaml
   - envoy-proxy.yaml
+  - envoy-proxy-metrics.yaml
   - httproutes.yaml
+  - httproutes-redirect.yaml
 release:
   name: csghub
   namespace: csghub
-set:
-  global:
-    gateway:
-      controllerName: "gateway.envoyproxy.io/gatewayclass-controller"
-      external:
-        domain: "csghub.example.cn"
-      tls:
-        enabled: true
-        secretName: "example-cn-tls"
-      service:
-        type: "NodePort"
-        nodePorts:
-          http: 30080
-          https: 30443
-          gitssh: 30022
-    image:
-      registry: "docker.io"
-    chartContext:
-      isBuiltIn: false
-  name: "runner-svc"
-  service:
-    port: 8082
+values:
+  - values.yaml
 tests:
-  - it: Should render gateway correctly
+  ## ------------------------------------------------------------------
+  ## gateway.yaml: standalone mode
+  ## ------------------------------------------------------------------
+  - it: renders the GatewayClass with the configured controller name
     template: gateway.yaml
-    documentIndex: 0
+    documentSelector:
+      path: metadata.name
+      value: csghub-gateway
     asserts:
+      - isKind:
+          of: GatewayClass
       - equal:
           path: spec.controllerName
           value: "gateway.envoyproxy.io/gatewayclass-controller"
 
-  - it: Should render gateway correctly
+  - it: renders the listeners Gateway with an envoy proxy parametersRef
     template: gateway.yaml
-    documentIndex: 1
+    documentSelector:
+      path: metadata.name
+      value: listeners
     asserts:
+      - isKind:
+          of: Gateway
+      - equal:
+          path: metadata.namespace
+          value: "csghub"
+      - equal:
+          path: spec.gatewayClassName
+          value: "csghub-gateway"
+      - equal:
+          path: spec.infrastructure.parametersRef.group
+          value: "gateway.envoyproxy.io"
+      - equal:
+          path: spec.infrastructure.parametersRef.kind
+          value: "EnvoyProxy"
+      - equal:
+          path: spec.infrastructure.parametersRef.name
+          value: "csghub-envoy-proxy"
+      - equal:
+          path: spec.listeners[0].name
+          value: "http"
+      - equal:
+          path: spec.listeners[0].protocol
+          value: "HTTP"
+      - equal:
+          path: spec.listeners[0].port
+          value: 80
+      - equal:
+          path: spec.listeners[0].allowedRoutes.namespaces.from
+          value: "Same"
+
+  - it: renders the knative Gateway with a namespace selector
+    template: gateway.yaml
+    documentSelector:
+      path: metadata.name
+      value: knative
+    asserts:
+      - isKind:
+          of: Gateway
+      - equal:
+          path: spec.infrastructure.parametersRef.name
+          value: "csghub-envoy-proxy-knative"
+      - equal:
+          path: spec.listeners[0].allowedRoutes.namespaces.from
+          value: "Selector"
+      - equal:
+          path: spec.listeners[0].allowedRoutes.namespaces.selector.matchExpressions[0].key
+          value: "kubernetes.io/metadata.name"
+      - equal:
+          path: spec.listeners[0].allowedRoutes.namespaces.selector.matchExpressions[0].operator
+          value: "In"
+      - contains:
+          path: spec.listeners[0].allowedRoutes.namespaces.selector.matchExpressions[0].values
+          content: "csghub"
+      - contains:
+          path: spec.listeners[0].allowedRoutes.namespaces.selector.matchExpressions[0].values
+          content: "spaces"
+      - contains:
+          path: spec.listeners[0].allowedRoutes.namespaces.selector.matchExpressions[0].values
+          content: "knative-serving"
+
+  - it: renders the knative-local Gateway
+    template: gateway.yaml
+    documentSelector:
+      path: metadata.name
+      value: knative-local
+    asserts:
+      - isKind:
+          of: Gateway
+      - equal:
+          path: spec.infrastructure.parametersRef.name
+          value: "csghub-envoy-proxy-knative-local"
+
+  ## ------------------------------------------------------------------
+  ## gateway.yaml: TLS
+  ## ------------------------------------------------------------------
+  - it: renders an https listener with certificate when TLS is enabled
+    template: gateway.yaml
+    documentSelector:
+      path: metadata.name
+      value: listeners
+    set:
+      global:
+        gateway:
+          tls:
+            enabled: true
+            secretName: "test-tls"
+    asserts:
+      - equal:
+          path: spec.listeners[1].name
+          value: "https"
       - equal:
           path: spec.listeners[1].protocol
           value: "HTTPS"
       - equal:
+          path: spec.listeners[1].port
+          value: 443
+      - equal:
+          path: spec.listeners[1].tls.mode
+          value: "Terminate"
+      - equal:
+          path: spec.listeners[1].tls.certificateRefs[0].kind
+          value: "Secret"
+      - equal:
           path: spec.listeners[1].tls.certificateRefs[0].name
-          value: "example-cn-tls"
+          value: "test-tls"
 
-  - it: Should render gateway correctly with local
+  ## ------------------------------------------------------------------
+  ## gateway.yaml: ingress modes
+  ## ------------------------------------------------------------------
+  - it: renders only GatewayClass and listeners in kourier mode
     template: gateway.yaml
-    documentIndex: 1
     set:
-      gateway:
-        tls:
-          secretName: "example-cn-tls-local"
+      knative:
+        serving:
+          ingress: "kourier"
     asserts:
-      - equal:
-          path: spec.listeners[1].tls.certificateRefs[0].name
-          value: "example-cn-tls-local"
+      - hasDocuments:
+          count: 2
 
-  - it: Should render httpRoutes correctly
-    template: httproutes.yaml
-    asserts:
-      - contains:
-          path: spec.hostnames
-          content: "runner-svc.example.cn"
-      - equal:
-          path: spec.rules[0].backendRefs[0].name
-          value: "csghub-runner-svc"
-      - equal:
-          path: spec.rules[0].backendRefs[0].port
-          value: 8082
-
-  - it: Should render envoy-proxy correctly
-    template: envoy-proxy.yaml
-    documentIndex: 0
-    asserts:
-      - equal:
-          path: spec.provider.kubernetes.envoyService.type
-          value: "NodePort"
-      - equal:
-          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[0].nodePort
-          value: 30080
-      - equal:
-          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[1].nodePort
-          value: 30443
-
-  - it: Should render envoy-proxy correctly
-    template: envoy-proxy.yaml
-    documentIndex: 0
+  - it: renders only the knative Gateways in builtIn mode
+    template: gateway.yaml
     set:
       global:
-        gateway:
-          service:
-            nodePorts:
-              http: 30880
-              https: 30444
-              gitssh: 30222
-        image:
-          registry: "opencsg-registry.cn-beijing.cr.aliyuncs.com"
+        chartContext:
+          isBuiltIn: true
     asserts:
-      - equal:
-          path: spec.provider.kubernetes.envoyService.type
-          value: "NodePort"
-      - equal:
-          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[0].nodePort
-          value: 30880
-      - equal:
-          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[1].nodePort
-          value: 30444
-      - equal:
-          path: spec.provider.kubernetes.envoyDeployment.container.image
-          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/envoyproxy/envoy:distroless-v1.37.5"
+      - hasDocuments:
+          count: 2
 
-  - it: Should render envoyDeployment as empty object when using non-opencsg registry
-    template: envoy-proxy.yaml
-    documentIndex: 0
-    set:
-      global:
-        image:
-          registry: "docker.io"
-    asserts:
-      - isKind:
-          of: "EnvoyProxy"
-      - equal:
-          path: spec.provider.kubernetes.envoyDeployment
-          value: {}
-
-  - it: Should render knative envoy-proxy with ClusterIP in builtIn mode
-    template: envoy-proxy.yaml
-    documentIndex: 0
+  - it: renders the knative Gateway in builtIn mode
+    template: gateway.yaml
+    documentSelector:
+      path: metadata.name
+      value: knative
     set:
       global:
         chartContext:
           isBuiltIn: true
     asserts:
       - isKind:
-          of: "EnvoyProxy"
+          of: Gateway
       - equal:
-          path: spec.provider.kubernetes.envoyService.type
-          value: "ClusterIP"
-      - notExists:
-          path: spec.provider.kubernetes.envoyService.externalTrafficPolicy
+          path: metadata.name
+          value: "knative"
 
-  - it: Should render knative envoy-proxy with NodePort and externalTrafficPolicy in standalone mode
-    template: envoy-proxy.yaml
-    documentIndex: 1
-    asserts:
-      - isKind:
-          of: "EnvoyProxy"
-      - equal:
-          path: spec.provider.kubernetes.envoyService.type
-          value: "NodePort"
-      - equal:
-          path: spec.provider.kubernetes.envoyService.externalTrafficPolicy
-          value: "Cluster"
-
-  - it: Should render knative envoy-proxy without externalTrafficPolicy when type is LoadBalancer
-    template: envoy-proxy.yaml
-    documentIndex: 1
+  - it: renders the knative-local Gateway in builtIn mode
+    template: gateway.yaml
+    documentSelector:
+      path: metadata.name
+      value: knative-local
     set:
       global:
-        gateway:
-          service:
-            type: "LoadBalancer"
+        chartContext:
+          isBuiltIn: true
     asserts:
       - isKind:
-          of: "EnvoyProxy"
+          of: Gateway
+      - equal:
+          path: metadata.name
+          value: "knative-local"
+
+  - it: renders nothing when the gateway is disabled
+    template: gateway.yaml
+    set:
+      gateway:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  ## ------------------------------------------------------------------
+  ## envoy-proxy.yaml: standalone mode
+  ## ------------------------------------------------------------------
+  - it: renders the main EnvoyProxy with an empty deployment for docker registry
+    template: envoy-proxy.yaml
+    documentSelector:
+      path: metadata.name
+      value: csghub-envoy-proxy
+    asserts:
+      - isKind:
+          of: EnvoyProxy
+      - equal:
+          path: metadata.namespace
+          value: "csghub"
+      - equal:
+          path: spec.provider.type
+          value: "Kubernetes"
+      - equal:
+          path: spec.provider.kubernetes.envoyDeployment
+          value: {}
+
+  - it: renders the knative EnvoyProxy with a LoadBalancer service
+    template: envoy-proxy.yaml
+    documentSelector:
+      path: metadata.name
+      value: csghub-envoy-proxy-knative
+    asserts:
+      - isKind:
+          of: EnvoyProxy
+      - equal:
+          path: spec.provider.kubernetes.envoyService.name
+          value: "csghub-envoy-knative"
       - equal:
           path: spec.provider.kubernetes.envoyService.type
           value: "LoadBalancer"
       - notExists:
           path: spec.provider.kubernetes.envoyService.externalTrafficPolicy
 
-  - it: Should NOT render knative gateways in kourier mode (default)
-    template: gateway.yaml
-    set:
-      knative:
-        serving:
-          ingress: kourier
-    asserts:
-      - hasDocuments:
-          count: 2
-
-  - it: Should render knative-gateway in gateway-api mode
-    template: gateway.yaml
-    documentIndex: 2
-    set:
-      knative:
-        serving:
-          ingress: gateway-api
+  - it: renders the knative-local EnvoyProxy with a ClusterIP service
+    template: envoy-proxy.yaml
+    documentSelector:
+      path: metadata.name
+      value: csghub-envoy-proxy-knative-local
     asserts:
       - isKind:
-          of: Gateway
+          of: EnvoyProxy
       - equal:
-          path: metadata.name
-          value: knative
+          path: spec.provider.kubernetes.envoyService.name
+          value: "csghub-envoy-knative-local"
       - equal:
-          path: spec.listeners[0].allowedRoutes.namespaces.from
-          value: Selector
-      - equal:
-          path: spec.listeners[0].allowedRoutes.namespaces.selector.matchExpressions[0].key
-          value: kubernetes.io/metadata.name
-      - equal:
-          path: spec.listeners[0].allowedRoutes.namespaces.selector.matchExpressions[0].operator
-          value: In
-      - contains:
-          path: spec.listeners[0].allowedRoutes.namespaces.selector.matchExpressions[0].values
-          content: csghub
-      - contains:
-          path: spec.listeners[0].allowedRoutes.namespaces.selector.matchExpressions[0].values
-          content: spaces
-      - contains:
-          path: spec.listeners[0].allowedRoutes.namespaces.selector.matchExpressions[0].values
-          content: knative-serving
+          path: spec.provider.kubernetes.envoyService.type
+          value: "ClusterIP"
 
-  - it: Should render knative gateway in gateway-api + builtIn mode
-    template: gateway.yaml
-    documentIndex: 0
+  ## ------------------------------------------------------------------
+  ## envoy-proxy.yaml: NodePort + TLS + OpenCSG registry
+  ## ------------------------------------------------------------------
+  - it: renders NodePort patch ports when the gateway type is NodePort
+    template: envoy-proxy.yaml
+    documentSelector:
+      path: metadata.name
+      value: csghub-envoy-proxy
+    set:
+      global:
+        gateway:
+          service:
+            type: NodePort
+            nodePorts:
+              http: 30080
+              https: 30443
+              gitssh: 30022
+          tls:
+            enabled: true
+            secretName: "test-tls"
+    asserts:
+      - equal:
+          path: spec.provider.kubernetes.envoyService.type
+          value: "NodePort"
+      - equal:
+          path: spec.provider.kubernetes.envoyService.externalTrafficPolicy
+          value: "Cluster"
+      - equal:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[0].name
+          value: "http-80"
+      - equal:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[0].nodePort
+          value: 30080
+      - equal:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[1].name
+          value: "http-443"
+      - equal:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[1].nodePort
+          value: 30443
+      - equal:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[2].name
+          value: "tcp-22"
+      - equal:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[2].port
+          value: 22
+      - equal:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[2].targetPort
+          value: 10022
+      - equal:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[2].nodePort
+          value: 30022
+
+  - it: overrides the envoy image for the OpenCSG registry
+    template: envoy-proxy.yaml
+    documentSelector:
+      path: metadata.name
+      value: csghub-envoy-proxy
+    set:
+      global:
+        gateway:
+          service:
+            type: NodePort
+            nodePorts:
+              http: 30080
+              https: 30443
+              gitssh: 30022
+        image:
+          registry: "opencsg-registry.cn-beijing.cr.aliyuncs.com"
+    asserts:
+      - equal:
+          path: spec.provider.kubernetes.envoyDeployment.container.image
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/envoyproxy/envoy:distroless-v1.37.5"
+
+  - it: omits the https port patch when TLS is disabled on NodePort
+    template: envoy-proxy.yaml
+    documentSelector:
+      path: metadata.name
+      value: csghub-envoy-proxy
+    set:
+      global:
+        gateway:
+          service:
+            type: NodePort
+            nodePorts:
+              http: 30080
+              https: 30443
+              gitssh: 30022
+    asserts:
+      - equal:
+          path: spec.provider.kubernetes.envoyService.type
+          value: "NodePort"
+      - equal:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[0].name
+          value: "http-80"
+      - equal:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[1].name
+          value: "tcp-22"
+      - notExists:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[2]
+
+  - it: pads short ssh ports and leaves long ssh ports unchanged
+    template: envoy-proxy.yaml
+    documentSelector:
+      path: metadata.name
+      value: csghub-envoy-proxy
+    set:
+      global:
+        gateway:
+          service:
+            type: NodePort
+            nodePorts:
+              http: 30080
+              https: 30443
+              gitssh: 30022
+      server:
+        gitlabShell:
+          sshPort: 2222
+    asserts:
+      - equal:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[1].name
+          value: "tcp-2222"
+      - equal:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[1].port
+          value: 2222
+      - equal:
+          path: spec.provider.kubernetes.envoyService.patch.value.spec.ports[1].targetPort
+          value: 2222
+
+  ## ------------------------------------------------------------------
+  ## envoy-proxy.yaml: builtIn and non-envoy controller
+  ## ------------------------------------------------------------------
+  - it: renders two EnvoyProxies in builtIn mode
+    template: envoy-proxy.yaml
     set:
       global:
         chartContext:
           isBuiltIn: true
-      knative:
-        serving:
-          ingress: gateway-api
     asserts:
       - hasDocuments:
           count: 2
-      - isKind:
-          of: Gateway
-      - equal:
-          path: metadata.name
-          value: knative
 
-  - it: Should render knative-local gateway in gateway-api + builtIn mode
-    template: gateway.yaml
-    documentIndex: 1
+  - it: renders the knative EnvoyProxy with ClusterIP in builtIn mode
+    template: envoy-proxy.yaml
+    documentSelector:
+      path: metadata.name
+      value: csghub-envoy-proxy-knative
     set:
       global:
         chartContext:
           isBuiltIn: true
+    asserts:
+      - equal:
+          path: spec.provider.kubernetes.envoyService.name
+          value: "csghub-envoy-knative"
+      - equal:
+          path: spec.provider.kubernetes.envoyService.type
+          value: "ClusterIP"
+
+  - it: renders the knative-local EnvoyProxy with ClusterIP in builtIn mode
+    template: envoy-proxy.yaml
+    documentSelector:
+      path: metadata.name
+      value: csghub-envoy-proxy-knative-local
+    set:
+      global:
+        chartContext:
+          isBuiltIn: true
+    asserts:
+      - equal:
+          path: spec.provider.kubernetes.envoyService.name
+          value: "csghub-envoy-knative-local"
+      - equal:
+          path: spec.provider.kubernetes.envoyService.type
+          value: "ClusterIP"
+
+  - it: renders no EnvoyProxy with a non-envoy controller
+    template: envoy-proxy.yaml
+    set:
+      global:
+        gateway:
+          controllerName: "istio.io/gateway-controller"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  ## ------------------------------------------------------------------
+  ## envoy-proxy-metrics.yaml
+  ## ------------------------------------------------------------------
+  - it: renders the listeners metrics service with prometheus annotations
+    template: envoy-proxy-metrics.yaml
+    documentSelector:
+      path: metadata.name
+      value: envoy-proxy-listeners-metrics
+    asserts:
+      - equal:
+          path: spec.type
+          value: "ClusterIP"
+      - equal:
+          path: metadata.annotations["prometheus.io/scrape"]
+          value: "true"
+      - equal:
+          path: metadata.annotations["prometheus.io/port"]
+          value: "19001"
+      - equal:
+          path: spec.selector["gateway.envoyproxy.io/owning-gateway-name"]
+          value: "listeners"
+      - equal:
+          path: spec.selector["gateway.envoyproxy.io/owning-gateway-namespace"]
+          value: "csghub"
+      - equal:
+          path: spec.ports[0].name
+          value: "metrics"
+      - equal:
+          path: spec.ports[0].port
+          value: 19001
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 19001
+
+  - it: renders the knative metrics service in gateway-api mode
+    template: envoy-proxy-metrics.yaml
+    documentSelector:
+      path: metadata.name
+      value: envoy-proxy-knative-metrics
+    asserts:
+      - equal:
+          path: spec.selector["gateway.envoyproxy.io/owning-gateway-name"]
+          value: "knative"
+      - equal:
+          path: spec.ports[0].port
+          value: 19001
+
+  - it: renders only the listeners metrics service in kourier mode
+    template: envoy-proxy-metrics.yaml
+    set:
       knative:
         serving:
-          ingress: gateway-api
+          ingress: "kourier"
     asserts:
-      - isKind:
-          of: Gateway
+      - hasDocuments:
+          count: 1
+
+  - it: renders the listeners metrics service name in kourier mode
+    template: envoy-proxy-metrics.yaml
+    documentSelector:
+      path: metadata.name
+      value: envoy-proxy-listeners-metrics
+    set:
+      knative:
+        serving:
+          ingress: "kourier"
+    asserts:
       - equal:
           path: metadata.name
-          value: knative-local
+          value: "envoy-proxy-listeners-metrics"
+      - equal:
+          path: spec.selector["gateway.envoyproxy.io/owning-gateway-name"]
+          value: "listeners"
+
+  ## ------------------------------------------------------------------
+  ## httproutes.yaml
+  ## ------------------------------------------------------------------
+  - it: renders the runner HTTPRoute with an http parent section
+    template: httproutes.yaml
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: metadata.name
+          value: "csghub-runner"
+      - equal:
+          path: metadata.namespace
+          value: "csghub"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/service"]
+          value: "csghub-runner"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: "csghub"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: "runner"
+      - equal:
+          path: spec.parentRefs[0].name
+          value: "listeners"
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: "http"
+      - contains:
+          path: spec.hostnames
+          content: "runner.example.com"
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: "PathPrefix"
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: "/"
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: "csghub-runner"
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 8082
+
+  - it: targets the https parent section when TLS is enabled
+    template: httproutes.yaml
+    set:
+      global:
+        gateway:
+          tls:
+            enabled: true
+            secretName: "test-tls"
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: "https"
+
+  - it: replaces common labels with service-level labels when set
+    template: httproutes.yaml
+    set:
+      labels:
+        foo: "bar"
+    asserts:
+      - equal:
+          path: metadata.labels["app.kubernetes.io/service"]
+          value: "csghub-runner"
+      - equal:
+          path: metadata.labels["foo"]
+          value: "bar"
+      - notExists:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+
+  - it: renders the hostname from the runner domain with useTop
+    template: httproutes.yaml
+    set:
+      global:
+        gateway:
+          external:
+            useTop: true
+    asserts:
+      - contains:
+          path: spec.hostnames
+          content: "runner.csghub.example.com"
+
+  - it: renders nothing when the gateway is disabled
+    template: httproutes.yaml
+    set:
+      gateway:
+        enabled: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  ## ------------------------------------------------------------------
+  ## httproutes-redirect.yaml
+  ## ------------------------------------------------------------------
+  - it: renders no redirect route when TLS is disabled
+    template: httproutes-redirect.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders an https redirect route when TLS is enabled
+    template: httproutes-redirect.yaml
+    set:
+      global:
+        gateway:
+          tls:
+            enabled: true
+            secretName: "test-tls"
+    asserts:
+      - isKind:
+          of: HTTPRoute
+      - equal:
+          path: metadata.name
+          value: "csghub-runner-redirect"
+      - equal:
+          path: metadata.namespace
+          value: "csghub"
+      - equal:
+          path: spec.parentRefs[0].name
+          value: "listeners"
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: "http"
+      - contains:
+          path: spec.hostnames
+          content: "runner.example.com"
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: "RequestRedirect"
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.scheme
+          value: "https"
+      - equal:
+          path: spec.rules[0].filters[0].requestRedirect.statusCode
+          value: 301

--- a/charts/runner/tests/knativeserving_test.yaml
+++ b/charts/runner/tests/knativeserving_test.yaml
@@ -1,198 +1,165 @@
+# Test suite for the runner KnativeServing resources.
+#
+# The template renders two documents: a Namespace and a KnativeServing CR.
+# Baseline is standalone mode (isBuiltIn=false) with gateway-api ingress and a
+# docker registry. All values are explicitly defined in tests/values.yaml.
+
 suite: Test Runner KnativeServing
 templates:
   - knativeserving.yaml
 release:
   name: csghub
   namespace: csghub
-set:
-  ## Global Definition
-  global:
-    gateway:
-      controllerName: gateway.envoyproxy.io/gatewayclass-controller
-      service:
-        type: LoadBalancer
-        nodePort: {}
-      external:
-        domain: csghub.unittest.io
-        public: ""
-        useTop: false
-      tls:
-        enabled: false
-        secretName: ""
-    image:
-      registry: unittest.io
-      registryPolicy: default
-      tag: v2.0.0
-      pullPolicy: IfNotPresent
-      pullSecrets: []
-    registry:
-      enabled: false
-    objectStore:
-      enabled: false
-    chartContext:
-      isBuiltIn: false
-
-  externalUrl: https://csghub.unittest.io
-  image:
-    repository: opencsghq/csghub-server
-    tag: v2.0.0
-    pullPolicy: IfNotPresent
-    pullSecrets: []
-  gateway:
-    enabled: true
-    tls: {}
-  hubAPIToken: unittest-api-token-standalone
-  originClusterID: unittest-cluster
-  region: es-west-1
-
-  name: runner-unittest
-
-  service:
-    type: ClusterIP
-    port: 8082
-    protocol: TCP
-
-  interval: 30
-
-  namespace: spaces
-  mergingNamespace: disable
-
-  usePublicDomain: true
-
-  pipIndexUrl: https://pypi.tuna.tsinghua.edu.cn/simple/
-
-  extraBuildArgs: []
-
-  model:
-    deployTimeout: 30
-    registry: model.unittest.io
-
-  gpuModelLabel:
-    typeLabel: nvidia.com/gpu.product
-    capacityLabel: nvidia.com/gpu
-
-  applicationEndpoint: http://kourier-internal.knative-serving.svc.cluster.local
-
-  networkInterface: eth0
-
-  storageClassName: local-path
-
-  knative:
-    serving:
-      domain: unittest.io
-      ingress: kourier
-      autoscaler:
-        enableScaleToZero: true
-        scaleToZeroPodRetentionPeriod: 30m
-
-  rbac:
-    create: true
-    serviceAccountName: runner-unittest
-
-  logcollector:
-    enabled: false
-    loki:
-      address: ""
-
-  tempo:
-    address: ""
-
-  registry:
-    registry: registry.unittest.io
-    repository: csghub
-    username: unittest
-    password: unittest
-    insecure: "true"
-
-  objectStore:
-    endpoint: https://s3.unittest.io
-    accessKey: unittest
-    secretKey: unittest
-    bucket: runner-unittest
-    region: cn-north-1
-    secure: "true"
-    encrypt: "false"
-    pathStyle: "true"
-
-  prometheus:
-    enabled: true
-    gateway:
-      enabled: false
-      basicAuth: {}
-    server:
-      remoteWrite: []
-
-  volcano:
-    enabled: true
-    basic:
-      image_pull_policy: IfNotPresent
-
+values:
+  - values.yaml
 tests:
-  - it: Should render Namespace metadata normally
-    documentIndex: 0
+  ## ------------------------------------------------------------------
+  ## Namespace document
+  ## ------------------------------------------------------------------
+  - it: renders the knative-serving Namespace metadata
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: Namespace
     asserts:
       - equal:
           path: metadata.name
-          value: knative-serving
-      - equal:
-          path: metadata.labels["app.kubernetes.io/service"]
-          value: csghub-runner-unittest
-      - equal:
-          path: metadata.labels["app.kubernetes.io/instance"]
-          value: csghub
+          value: "knative-serving"
       - equal:
           path: metadata.labels["app.kubernetes.io/managed-by"]
-          value: Helm
+          value: "Helm"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: "csghub"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/service"]
+          value: "csghub-runner"
       - equal:
           path: metadata.annotations["helm.sh/resource-policy"]
-          value: keep
+          value: "keep"
 
-  - it: Should render KnativeServing CR metadata normally
-    documentIndex: 1
+  - it: renders the knative Namespace in the release namespace when merging is single
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: Namespace
+    set:
+      runner:
+        mergingNamespace: "single"
     asserts:
       - equal:
           path: metadata.name
-          value: knative-serving
+          value: "csghub"
+
+  ## ------------------------------------------------------------------
+  ## KnativeServing CR metadata
+  ## ------------------------------------------------------------------
+  - it: renders the KnativeServing CR metadata
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: KnativeServing
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "knative-serving"
       - equal:
           path: metadata.namespace
-          value: knative-serving
-      - equal:
-          path: metadata.labels["app.kubernetes.io/service"]
-          value: csghub-runner-unittest
-      - equal:
-          path: metadata.labels["app.kubernetes.io/instance"]
-          value: csghub
+          value: "knative-serving"
       - equal:
           path: metadata.labels["app.kubernetes.io/managed-by"]
-          value: Helm
+          value: "Helm"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: "csghub"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/service"]
+          value: "csghub-runner"
       - equal:
           path: metadata.annotations["meta.helm.sh/release-name"]
-          value: csghub
+          value: "csghub"
       - equal:
           path: metadata.annotations["meta.helm.sh/release-namespace"]
-          value: csghub
+          value: "csghub"
 
-  - it: Should render KnativeServing spec normally
-    documentIndex: 1
+  - it: adds a post-install hook annotation on install
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: KnativeServing
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: "post-install"
+
+  - it: adds a post-upgrade hook annotation on upgrade
+    template: knativeserving.yaml
+    release:
+      name: csghub
+      namespace: csghub
+      upgrade: true
+    documentSelector:
+      path: kind
+      value: KnativeServing
+    asserts:
+      - equal:
+          path: metadata.annotations["helm.sh/hook"]
+          value: "post-upgrade"
+
+  ## ------------------------------------------------------------------
+  ## KnativeServing CR spec: gateway-api mode (baseline)
+  ## ------------------------------------------------------------------
+  - it: renders the baseline KnativeServing spec in gateway-api mode
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: KnativeServing
     asserts:
       - equal:
           path: spec.version
           value: "1.22"
       - equal:
           path: spec.ingress.kourier.enabled
+          value: false
+      - equal:
+          path: spec.ingress.gateway-api.enabled
           value: true
       - equal:
-          path: spec.config.domain["unittest.io"]
+          path: spec.ingress.istio.enabled
+          value: false
+      - equal:
+          path: spec.config.domain["example.com"]
           value: ""
       - equal:
           path: spec.config.autoscaler.enable-scale-to-zero
           value: "true"
       - equal:
           path: spec.config.autoscaler.scale-to-zero-pod-retention-period
-          value: 30m
+          value: "60m"
       - equal:
           path: spec.config.network.ingress-class
-          value: kourier.ingress.networking.knative.dev
+          value: "gateway-api.ingress.networking.knative.dev"
+      - equal:
+          path: spec.config["gateway"]["external-gateways"]
+          value: |
+            - class: eg-external
+              gateway: csghub/knative
+              supported-features:
+              - HTTPRouteRequestTimeout
+      - equal:
+          path: spec.config["gateway"]["local-gateways"]
+          value: |
+            - class: eg-internal
+              gateway: csghub/knative-local
+              supported-features:
+              - HTTPRouteRequestTimeout
+
+  - it: renders the enabled knative features
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: KnativeServing
+    asserts:
       - equal:
           path: spec.config.features["kubernetes.podspec-priorityclassname"]
           value: "enabled"
@@ -241,75 +208,172 @@ tests:
       - equal:
           path: spec.config.features["tag-header-based-routing"]
           value: "enabled"
+
+  - it: renders the tag resolving list from externalUrl and global registry
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: KnativeServing
+    asserts:
       - equal:
           path: spec.config.deployment.registries-skipping-tag-resolving
-          value: "csghub.unittest.io,csghub.unittest.io,unittest.io"
+          value: "csghub.example.com,csghub.example.com,docker.io"
 
-  - it: Should render KnativeServing with scale-to-zero disabled
+  - it: composes the tag resolving list from domain, externalUrl and registry
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: KnativeServing
+    set:
+      externalUrl: "https://hub.other.com"
+      global:
+        image:
+          registry: "myreg.io"
+    asserts:
+      - equal:
+          path: spec.config.deployment.registries-skipping-tag-resolving
+          value: "csghub.example.com,hub.other.com,myreg.io"
+
+  - it: renders the observability configuration
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: KnativeServing
+    asserts:
+      - equal:
+          path: spec.config.observability.metrics-protocol
+          value: "prometheus"
+      - equal:
+          path: spec.config.observability.request-metrics-protocol
+          value: "prometheus"
+      - equal:
+          path: spec.config.observability.request-metrics-endpoint
+          value: ":9091"
+
+  ## ------------------------------------------------------------------
+  ## KnativeServing CR spec: kourier mode
+  ## ------------------------------------------------------------------
+  - it: renders the kourier ingress in kourier mode
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: KnativeServing
+    set:
+      knative:
+        serving:
+          ingress: "kourier"
+    asserts:
+      - equal:
+          path: spec.ingress.kourier.enabled
+          value: true
+      - notExists:
+          path: spec.ingress.gateway-api
+      - equal:
+          path: spec.config.network.ingress-class
+          value: "kourier.ingress.networking.knative.dev"
+      - notExists:
+          path: spec.config["gateway"]
+
+  ## ------------------------------------------------------------------
+  ## KnativeServing CR spec: OpenCSG registry override
+  ## ------------------------------------------------------------------
+  - it: overrides serving images for the OpenCSG registry in gateway-api mode
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: KnativeServing
+    set:
+      global:
+        image:
+          registry: "opencsg-registry.cn-beijing.cr.aliyuncs.com"
+    asserts:
+      - equal:
+          path: spec.registry.override.activator
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/knative-releases/knative.dev/serving/cmd/activator:v1.22.0"
+      - equal:
+          path: spec.registry.override.controller
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/knative-releases/knative.dev/serving/cmd/controller:v1.22.0"
+      - equal:
+          path: spec.registry.override.webhook
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/knative-releases/knative.dev/serving/cmd/webhook:v1.22.0"
+      - equal:
+          path: spec.registry.override["net-gateway-api-controller/controller"]
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/knative-releases/knative.dev/net-gateway-api/cmd/controller:v1.22.0"
+      - equal:
+          path: spec.registry.override["net-gateway-api-webhook/webhook"]
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/knative-releases/knative.dev/net-gateway-api/cmd/webhook:v1.22.0"
+      - equal:
+          path: spec.config.deployment.registries-skipping-tag-resolving
+          value: "csghub.example.com,csghub.example.com,opencsg-registry.cn-beijing.cr.aliyuncs.com"
+      - equal:
+          path: spec.config.deployment.queue-sidecar-image
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/knative-releases/knative.dev/serving/cmd/queue:v1.22.0"
+
+  - it: overrides the kourier images for the OpenCSG registry in kourier mode
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: KnativeServing
+    set:
+      global:
+        image:
+          registry: "opencsg-registry.cn-beijing.cr.aliyuncs.com"
+      knative:
+        serving:
+          ingress: "kourier"
+    asserts:
+      - equal:
+          path: spec.registry.override["net-kourier-controller/controller"]
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/knative-releases/knative.dev/net-kourier/cmd/kourier:v1.22.0"
+      - equal:
+          path: spec.registry.override["3scale-kourier-gateway/kourier-gateway"]
+          value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/envoyproxy/envoy:v1.37-latest"
+
+  ## ------------------------------------------------------------------
+  ## KnativeServing CR spec: autoscaler and domain overrides
+  ## ------------------------------------------------------------------
+  - it: disables scale to zero when configured
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: KnativeServing
     set:
       knative:
         serving:
           autoscaler:
             enableScaleToZero: false
-    documentIndex: 1
     asserts:
       - equal:
           path: spec.config.autoscaler.enable-scale-to-zero
           value: "false"
 
-  - it: Should render KnativeServing with custom domain
-    documentIndex: 1
-    set:
-      knative:
-        serving:
-          domain: custom.io
-    asserts:
-      - equal:
-          path: spec.config.domain["custom.io"]
-          value: ""
-      - notEqual:
-          path: spec.config.domain["unittest.io"]
-          value: ""
-
-  - it: Should render KnativeServing with custom grace period
+  - it: renders a custom scale-to-zero retention period
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: KnativeServing
     set:
       knative:
         serving:
           autoscaler:
-            scaleToZeroPodRetentionPeriod: 60s
-    documentIndex: 1
+            scaleToZeroPodRetentionPeriod: "30s"
     asserts:
       - equal:
           path: spec.config.autoscaler.scale-to-zero-pod-retention-period
-          value: 60s
+          value: "30s"
 
-  - it: Should render KnativeServing with Gateway API ingress
+  - it: renders a custom domain
+    template: knativeserving.yaml
+    documentSelector:
+      path: kind
+      value: KnativeServing
     set:
       knative:
         serving:
-          ingress: gateway-api
-    documentIndex: 1
+          domain: "custom.io"
     asserts:
       - equal:
-          path: spec.ingress.kourier.enabled
-          value: false
-      - equal:
-          path: spec.ingress.gateway-api.enabled
-          value: true
-      - equal:
-          path: spec.config.network.ingress-class
-          value: gateway-api.ingress.networking.knative.dev
-      - equal:
-          path: spec.config["gateway"]["external-gateways"]
-          value: |
-            - class: eg-external
-              gateway: csghub/knative
-              supported-features:
-              - HTTPRouteRequestTimeout
-      - equal:
-          path: spec.config["gateway"]["local-gateways"]
-          value: |
-            - class: eg-internal
-              gateway: csghub/knative-local
-              supported-features:
-              - HTTPRouteRequestTimeout
+          path: spec.config.domain["custom.io"]
+          value: ""
+      - notExists:
+          path: spec.config.domain["example.com"]

--- a/charts/runner/tests/namespace_test.yaml
+++ b/charts/runner/tests/namespace_test.yaml
@@ -1,0 +1,52 @@
+# Test suite for the runner spaces Namespace.
+#
+# The Namespace for user workloads is created when it does not already exist
+# (lookup returns empty in unit tests). Its name follows namespace.spaces,
+# which respects runner.mergingNamespace.
+
+suite: Test Runner Namespace
+templates:
+  - namespace.yaml
+release:
+  name: csghub
+  namespace: csghub
+values:
+  - values.yaml
+tests:
+  - it: renders the spaces Namespace with a keep annotation
+    template: namespace.yaml
+    asserts:
+      - isKind:
+          of: Namespace
+      - equal:
+          path: metadata.name
+          value: "spaces"
+      - equal:
+          path: metadata.labels["kubernetes.io/metadata.name"]
+          value: "spaces"
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: "keep"
+
+  - it: renders the Namespace in the release namespace when merging is single
+    template: namespace.yaml
+    set:
+      runner:
+        mergingNamespace: "single"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "csghub"
+      - equal:
+          path: metadata.labels["kubernetes.io/metadata.name"]
+          value: "csghub"
+
+  - it: renders the Namespace with a custom name from runner.namespace
+    template: namespace.yaml
+    set:
+      runner:
+        namespace: "tenant-a"
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "tenant-a"

--- a/charts/runner/tests/rbac-argo_test.yaml
+++ b/charts/runner/tests/rbac-argo_test.yaml
@@ -1,0 +1,142 @@
+# Test suite for the runner Argo RBAC resources.
+#
+# The template renders a dedicated argo workflow executor Role, ServiceAccount
+# and RoleBinding, plus an addon Role/RoleBinding for the workflow controller,
+# all scoped to the spaces namespace.
+#
+# Document order follows the template: Role executor(0), ServiceAccount(1),
+# RoleBinding executor(2), Role addon(3), RoleBinding addon(4).
+
+suite: Test Runner Argo RBAC
+templates:
+  - rbac-argo.yaml
+release:
+  name: csghub
+  namespace: csghub
+values:
+  - values.yaml
+tests:
+  - it: renders 5 documents in the spaces namespace
+    template: rbac-argo.yaml
+    asserts:
+      - hasDocuments:
+          count: 5
+
+  - it: renders nothing when RBAC creation is disabled
+    template: rbac-argo.yaml
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the argo workflow executor Role
+    template: rbac-argo.yaml
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: "csghub-argo-workflow-executor"
+      - equal:
+          path: metadata.namespace
+          value: "spaces"
+      - contains:
+          path: rules[0].resources
+          content: "pods/exec"
+      - contains:
+          path: rules[1].apiGroups
+          content: "argoproj.io"
+      - contains:
+          path: rules[1].resources
+          content: "cronworkflows"
+      - contains:
+          path: rules[2].resources
+          content: "secrets"
+
+  - it: renders the argo workflow executor ServiceAccount
+    template: rbac-argo.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: "csghub-argo-workflow-executor"
+      - equal:
+          path: metadata.namespace
+          value: "spaces"
+
+  - it: renders the argo workflow executor RoleBinding
+    template: rbac-argo.yaml
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.name
+          value: "csghub-argo-workflow-executor"
+      - equal:
+          path: metadata.namespace
+          value: "spaces"
+      - equal:
+          path: roleRef.name
+          value: "csghub-argo-workflow-executor"
+      - equal:
+          path: subjects[0].kind
+          value: "ServiceAccount"
+      - equal:
+          path: subjects[0].name
+          value: "csghub-argo-workflow-executor"
+      - equal:
+          path: subjects[0].namespace
+          value: "spaces"
+
+  - it: renders the argo workflow controller addon Role
+    template: rbac-argo.yaml
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: "csghub-argo-workflow-executor-addon"
+      - equal:
+          path: metadata.namespace
+          value: "spaces"
+      - equal:
+          path: rules[0].resources[0]
+          value: "secrets"
+      - equal:
+          path: rules[0].verbs
+          value: ["get", "list"]
+
+  - it: binds the addon Role to the workflow controller ServiceAccount
+    template: rbac-argo.yaml
+    documentIndex: 4
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.name
+          value: "csghub-argo-workflow-executor-addon"
+      - equal:
+          path: metadata.namespace
+          value: "spaces"
+      - equal:
+          path: roleRef.kind
+          value: "Role"
+      - equal:
+          path: roleRef.name
+          value: "csghub-argo-workflow-executor-addon"
+      - equal:
+          path: subjects[0].kind
+          value: "ServiceAccount"
+      - equal:
+          path: subjects[0].name
+          value: "csghub-argo-workflow-controller"
+      - equal:
+          path: subjects[0].namespace
+          value: "csghub"

--- a/charts/runner/tests/rbac_test.yaml
+++ b/charts/runner/tests/rbac_test.yaml
@@ -1,37 +1,246 @@
-# tests/rbac_test.yaml
+# Test suite for the runner RBAC resources.
+#
+# The template renders RBAC objects for the runner service account, plus a
+# ClusterRole/ClusterRoleBinding when the spaces namespace differs from the
+# release namespace. Baseline (namespace.spaces=spaces, release=csghub)
+# renders 8 documents; with merging into the release namespace it renders 6.
+#
+# Document order follows the template: ServiceAccount(0), Role watch-config(1),
+# RoleBinding watch-config(2), Role runner(3), RoleBinding runner(4),
+# RoleBinding argo-executor(5), ClusterRole(6), ClusterRoleBinding(7).
+
 suite: Test Runner RBAC
 templates:
   - rbac.yaml
 release:
-  name: runner
+  name: csghub
   namespace: csghub
+values:
+  - values.yaml
 tests:
-  - it: should create multiple RBAC with global.namespace <> Release.Namespace
-    set:
-      runner:
-        namespace: "spaces"
-      rbac.create: true
+  ## ------------------------------------------------------------------
+  ## Document counts
+  ## ------------------------------------------------------------------
+  - it: renders 8 documents when the spaces namespace differs from release namespace
+    template: rbac.yaml
     asserts:
       - hasDocuments:
           count: 8
-      - exists:
-          path: metadata
-          docSelector:
-            kind: ClusterRole
-            name: runner-cluster-reader
-        name: ClusterRole should be created
-      - exists:
-          path: metadata
-          docSelector:
-            kind: ClusterRoleBinding
-            name: runner-cluster-reader
-        name: ClusterRoleBinding should be created
 
-  - it: should create multiple RBAC with global.namespace = Release.Namespace
+  - it: renders 6 documents when the spaces namespace equals the release namespace
+    template: rbac.yaml
     set:
       runner:
         namespace: "csghub"
-      rbac.create: true
     asserts:
       - hasDocuments:
           count: 6
+
+  - it: renders nothing when RBAC creation is disabled
+    template: rbac.yaml
+    set:
+      rbac:
+        create: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  ## ------------------------------------------------------------------
+  ## ServiceAccount
+  ## ------------------------------------------------------------------
+  - it: renders the runner ServiceAccount in the release namespace
+    template: rbac.yaml
+    documentIndex: 0
+    asserts:
+      - isKind:
+          of: ServiceAccount
+      - equal:
+          path: metadata.name
+          value: "csghub-runner"
+      - equal:
+          path: metadata.namespace
+          value: "csghub"
+
+  ## ------------------------------------------------------------------
+  ## Watch config Role and RoleBinding
+  ## ------------------------------------------------------------------
+  - it: renders the watch-config Role in the release namespace
+    template: rbac.yaml
+    documentIndex: 1
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: "csghub-runner-watch-config"
+      - equal:
+          path: metadata.namespace
+          value: "csghub"
+      - equal:
+          path: rules[0].apiGroups[0]
+          value: ""
+      - equal:
+          path: rules[0].resources[0]
+          value: "configmaps"
+      - equal:
+          path: rules[0].verbs
+          value: ["get", "list", "watch"]
+
+  - it: renders the watch-config RoleBinding bound to the runner ServiceAccount
+    template: rbac.yaml
+    documentIndex: 2
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.name
+          value: "csghub-runner-watch-config"
+      - equal:
+          path: metadata.namespace
+          value: "csghub"
+      - equal:
+          path: subjects[0].kind
+          value: "ServiceAccount"
+      - equal:
+          path: subjects[0].name
+          value: "csghub-runner"
+      - equal:
+          path: subjects[0].namespace
+          value: "csghub"
+      - equal:
+          path: roleRef.kind
+          value: "Role"
+      - equal:
+          path: roleRef.name
+          value: "csghub-runner-watch-config"
+
+  ## ------------------------------------------------------------------
+  ## Spaces namespace Role and RoleBinding
+  ## ------------------------------------------------------------------
+  - it: renders the runner Role in the spaces namespace with workload rules
+    template: rbac.yaml
+    documentIndex: 3
+    asserts:
+      - isKind:
+          of: Role
+      - equal:
+          path: metadata.name
+          value: "csghub-runner"
+      - equal:
+          path: metadata.namespace
+          value: "spaces"
+      - contains:
+          path: rules[0].resources
+          content: "resourcequotas"
+      - contains:
+          path: rules[1].resources
+          content: "pods"
+      - contains:
+          path: rules[1].resources
+          content: "workflows"
+      - contains:
+          path: rules[1].resources
+          content: "revisions"
+      - contains:
+          path: rules[1].apiGroups
+          content: "argoproj.io"
+      - contains:
+          path: rules[2].apiGroups
+          content: "agents.x-k8s.io"
+      - contains:
+          path: rules[2].resources
+          content: "sandboxes"
+
+  - it: renders the runner RoleBinding in the spaces namespace
+    template: rbac.yaml
+    documentIndex: 4
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.name
+          value: "csghub-runner"
+      - equal:
+          path: metadata.namespace
+          value: "spaces"
+      - equal:
+          path: roleRef.name
+          value: "csghub-runner"
+
+  ## ------------------------------------------------------------------
+  ## Argo executor RoleBinding
+  ## ------------------------------------------------------------------
+  - it: binds the runner ServiceAccount to the argo workflow executor Role
+    template: rbac.yaml
+    documentIndex: 5
+    asserts:
+      - isKind:
+          of: RoleBinding
+      - equal:
+          path: metadata.name
+          value: "csghub-runner-argo-workflow-executor"
+      - equal:
+          path: metadata.namespace
+          value: "spaces"
+      - equal:
+          path: roleRef.name
+          value: "csghub-argo-workflow-executor"
+      - equal:
+          path: subjects[0].name
+          value: "csghub-runner"
+
+  ## ------------------------------------------------------------------
+  ## ClusterRole and ClusterRoleBinding
+  ## ------------------------------------------------------------------
+  - it: renders the ClusterRole with cluster-wide node and namespace rules
+    template: rbac.yaml
+    documentIndex: 6
+    asserts:
+      - isKind:
+          of: ClusterRole
+      - equal:
+          path: metadata.name
+          value: "csghub-runner"
+      - contains:
+          path: rules[0].resources
+          content: "nodes"
+      - contains:
+          path: rules[0].resources
+          content: "pods"
+      - equal:
+          path: rules[1].resourceNames[0]
+          value: "spaces"
+      - contains:
+          path: rules[2].resourceNames
+          content: "kourier"
+      - contains:
+          path: rules[3].resources
+          content: "sandboxes"
+      - contains:
+          path: rules[4].resources
+          content: "persistentvolumeclaims"
+
+  - it: binds the runner ServiceAccount with the ClusterRole
+    template: rbac.yaml
+    documentIndex: 7
+    asserts:
+      - isKind:
+          of: ClusterRoleBinding
+      - equal:
+          path: metadata.name
+          value: "csghub-runner"
+      - equal:
+          path: roleRef.kind
+          value: "ClusterRole"
+      - equal:
+          path: roleRef.name
+          value: "csghub-runner"
+      - equal:
+          path: subjects[0].kind
+          value: "ServiceAccount"
+      - equal:
+          path: subjects[0].name
+          value: "csghub-runner"
+      - equal:
+          path: subjects[0].namespace
+          value: "csghub"

--- a/charts/runner/tests/resource-quota_test.yaml
+++ b/charts/runner/tests/resource-quota_test.yaml
@@ -1,0 +1,52 @@
+# Test suite for the runner ResourceQuota.
+#
+# The quota renders when resourceQuota.enabled is true or when the global
+# edition is "saas". Baseline disables it.
+
+suite: Test Runner ResourceQuota
+templates:
+  - resource-quota.yaml
+release:
+  name: csghub
+  namespace: csghub
+values:
+  - values.yaml
+tests:
+  - it: renders nothing when resourceQuota is disabled
+    template: resource-quota.yaml
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: renders the gpu quota in the spaces namespace when enabled
+    template: resource-quota.yaml
+    set:
+      resourceQuota:
+        enabled: true
+    asserts:
+      - isKind:
+          of: ResourceQuota
+      - equal:
+          path: metadata.name
+          value: "csghub-gpu-quota"
+      - equal:
+          path: metadata.namespace
+          value: "spaces"
+      - equal:
+          path: spec.hard["requests.nvidia.com/gpu"]
+          value: "2"
+      - equal:
+          path: spec.hard["limits.nvidia.com/gpu"]
+          value: "2"
+
+  - it: renders the gpu quota when the global edition is saas
+    template: resource-quota.yaml
+    set:
+      global:
+        edition: "saas"
+    asserts:
+      - isKind:
+          of: ResourceQuota
+      - equal:
+          path: metadata.name
+          value: "csghub-gpu-quota"

--- a/charts/runner/tests/secret_test.yaml
+++ b/charts/runner/tests/secret_test.yaml
@@ -1,0 +1,60 @@
+# Test suite for the runner docker credential Secret.
+#
+# The Secret is created in the spaces namespace when it does not already exist
+# (lookup returns empty in unit tests). The docker config JSON is built from
+# the explicit external registry values in tests/values.yaml.
+#
+# NOTE: The Secret is emitted only when the secret lookup is empty, which is
+# always the case for helm-unittest; the existing-secret path cannot be tested.
+
+suite: Test Runner Secret
+templates:
+  - secret.yaml
+release:
+  name: csghub
+  namespace: csghub
+values:
+  - values.yaml
+tests:
+  - it: renders the docker credential Secret metadata
+    template: secret.yaml
+    asserts:
+      - equal:
+          path: metadata.name
+          value: "csghub-docker-credential"
+      - equal:
+          path: metadata.namespace
+          value: "spaces"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/service"]
+          value: "csghub-runner"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: "csghub"
+      - equal:
+          path: metadata.annotations["helm.sh/resource-policy"]
+          value: "keep"
+      - equal:
+          path: type
+          value: "kubernetes.io/dockerconfigjson"
+
+  - it: renders the docker config JSON with the baseline registry credentials
+    template: secret.yaml
+    asserts:
+      - equal:
+          path: data[".dockerconfigjson"]
+          value: "eyJhdXRocyI6eyJyZWdpc3RyeS5leGFtcGxlLmNvbSI6eyJ1c2VybmFtZSI6InRlc3QtdXNlciIsInBhc3N3b3JkIjoidGVzdC1wYXNzIiwiYXV0aCI6ImRHVnpkQzExYzJWeU9uUmxjM1F0Y0dGemN3PT0ifX19"
+
+  - it: rebuilds the docker config JSON with overridden registry credentials
+    template: secret.yaml
+    set:
+      registry:
+        registry: "myreg.example.net"
+        repository: "team"
+        username: "alice"
+        password: "s3cret"
+        insecure: "true"
+    asserts:
+      - equal:
+          path: data[".dockerconfigjson"]
+          value: "eyJhdXRocyI6eyJteXJlZy5leGFtcGxlLm5ldCI6eyJ1c2VybmFtZSI6ImFsaWNlIiwicGFzc3dvcmQiOiJzM2NyZXQiLCJhdXRoIjoiWVd4cFkyVTZjek5qY21WMCJ9fX0="

--- a/charts/runner/tests/service_test.yaml
+++ b/charts/runner/tests/service_test.yaml
@@ -1,30 +1,106 @@
+# Test suite for the runner Service resource.
+#
+# The Service exposes the runner port (8082 by default) and selects pods by the
+# runner service label. Baseline comes from tests/values.yaml.
+
 suite: Test Runner Service
 templates:
   - service.yaml
 release:
   name: csghub
   namespace: csghub
-set:
-  name: "runner-svc"
-  service:
-    port: 8082
+values:
+  - values.yaml
 tests:
-  - it: Should render service correctly
+  - it: renders the runner Service metadata and labels
     template: service.yaml
-    set:
-      casdoor:
-        console:
-          enabled: true
     asserts:
       - equal:
-          path: metadata.labels["app.kubernetes.io/service"]
-          value: "runner-svc"
+          path: metadata.name
+          value: "csghub-runner"
       - equal:
-          path: spec.selector["app.kubernetes.io/service"]
-          value: "runner-svc"
+          path: metadata.namespace
+          value: "csghub"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/service"]
+          value: "runner"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/instance"]
+          value: "csghub"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/name"]
+          value: "runner"
+      - equal:
+          path: metadata.labels["app.kubernetes.io/managed-by"]
+          value: "Helm"
+
+  - it: renders the runner Service spec with default port
+    template: service.yaml
+    asserts:
       - equal:
           path: spec.type
           value: "ClusterIP"
       - equal:
           path: spec.ports[0].port
           value: 8082
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 8082
+      - equal:
+          path: spec.ports[0].protocol
+          value: "TCP"
+      - equal:
+          path: spec.ports[0].name
+          value: "runner"
+      - equal:
+          path: spec.selector["app.kubernetes.io/service"]
+          value: "runner"
+      - equal:
+          path: spec.selector["app.kubernetes.io/instance"]
+          value: "csghub"
+      - equal:
+          path: spec.selector["app.kubernetes.io/name"]
+          value: "runner"
+
+  - it: renders a NodePort type when service.type is overridden
+    template: service.yaml
+    set:
+      service:
+        type: NodePort
+    asserts:
+      - equal:
+          path: spec.type
+          value: "NodePort"
+
+  - it: renders a custom port when service.port is overridden
+    template: service.yaml
+    set:
+      service:
+        port: 9090
+    asserts:
+      - equal:
+          path: spec.ports[0].port
+          value: 9090
+      - equal:
+          path: spec.ports[0].targetPort
+          value: 8082
+
+  - it: renders a custom protocol when service.protocol is overridden
+    template: service.yaml
+    set:
+      service:
+        protocol: "UDP"
+    asserts:
+      - equal:
+          path: spec.ports[0].protocol
+          value: "UDP"
+
+  - it: renders a LoadBalancer type when service.type is overridden
+    template: service.yaml
+    set:
+      service:
+        type: "LoadBalancer"
+    asserts:
+      - equal:
+          path: spec.type
+          value: "LoadBalancer"

--- a/charts/runner/tests/values.yaml
+++ b/charts/runner/tests/values.yaml
@@ -1,0 +1,180 @@
+# Shared baseline values for CSGHub Runner unit tests.
+#
+# Every value consumed by the templates is defined EXPLICITLY below.
+# Tests never rely on the default values shipped in values.yaml, so
+# changing those defaults cannot break the unit tests.
+#
+# Release context is fixed as release=csghub, namespace=csghub.
+# The chart is rendered in standalone mode (isBuiltIn=false) by default;
+# built-in (umbrella) mode is exercised via per-test overrides.
+
+## Global Configuration
+global:
+  ## Gateway configuration
+  gateway:
+    controllerName: gateway.envoyproxy.io/gatewayclass-controller
+    service:
+      type: LoadBalancer
+      nodePorts:
+        http: 30080
+        https: 30443
+        gitssh: 30022
+    external:
+      domain: csghub.example.com
+      public: ""
+      useTop: false
+    tls:
+      enabled: false
+      secretName: ""
+  ## Image management
+  image:
+    registry: docker.io
+    registryPolicy: default
+    tag: v2.4.0
+    pullPolicy: IfNotPresent
+    pullSecrets: []
+  ## Internal registry flag (standalone mode uses external registry)
+  registry:
+    enabled: false
+  ## Internal object store flag
+  objectStore:
+    enabled: false
+  ## SubChart deployment context (standalone)
+  chartContext:
+    isBuiltIn: false
+  ## Image edition suffix (v2.4.0 -> v2.4.0-ee)
+  edition: ee
+
+## CSGHub Configuration
+externalUrl: "https://csghub.example.com"
+
+## Global image configuration (used by the runner deployment)
+image:
+  repository: opencsghq/csghub-server
+  tag: v2.4.0
+  pullPolicy: IfNotPresent
+  pullSecrets: []
+
+## Gateway enablement (service-level override for common.gateway.config)
+gateway:
+  enabled: true
+  tls: {}
+
+## API token for standalone mode
+hubAPIToken: "test-hub-api-token"
+
+## Unique identifier for the origin cluster
+originClusterID: "test-cluster-id"
+
+## Log level for the runner binary
+logging:
+  level: info
+
+## Defined resource name
+name: "runner"
+
+## Service configuration
+service:
+  type: ClusterIP
+  port: 8082
+  protocol: TCP
+
+## Runner configuration
+runner:
+  region: "test-region"
+  namespace: "spaces"
+  mergingNamespace: "disable"
+  interval: 30
+  hearBeatIntervalInSec: 120
+  applicationEndpoint: ""
+  networkInterface: ""
+  storageClassName: ""
+  allowCpuOnGpuNodes: false
+  imageBuilderGitImage: ""
+  imageBuilderKanikoImage: ""
+  imageBuilderStatusTTL: 300
+  imageBuilderKanikoArgs: []
+
+## Model deploy configuration
+model:
+  deployTimeoutInMin: 60
+  deployStatusCheckInterval: 10
+  dockerRegBase: ""
+
+## Space deploy configuration
+space:
+  usePublicDomain: true
+  pipIndexUrl: "https://pypi.example.com/simple"
+  deployTimeoutInMin: 30
+  buildTimeoutInMin: 30
+  statusCheckInterval: 10
+  readinessDelaySeconds: 120
+  readinessPeriodSeconds: 10
+  readinessFailureThreshold: 3
+  gpuModelLabel:
+    typeLabel: nvidia.com/gpu.product
+    capacityLabel: nvidia.com/gpu
+
+## Knative Serving configuration
+knative:
+  serving:
+    domain: "example.com"
+    ingress: "gateway-api"
+    autoscaler:
+      enableScaleToZero: true
+      scaleToZeroPodRetentionPeriod: "60m"
+
+## RBAC configuration
+rbac:
+  create: true
+  serviceAccountName: ""
+
+## Logcollector configuration
+logcollector:
+  enabled: false
+  loki:
+    address: ""
+
+## Trace logging configuration
+tempo:
+  address: ""
+
+## External registry configuration (empty insecure avoids skip-tls flags)
+registry:
+  registry: "registry.example.com"
+  repository: "csghub"
+  username: "test-user"
+  password: "test-pass"
+  insecure: ""
+
+## External object store configuration
+objectStore:
+  endpoint: "https://s3.example.com"
+  accessKey: "test-access"
+  secretKey: "test-secret"
+  bucket: "test-bucket"
+  region: "cn-north-1"
+  secure: "true"
+  pathStyle: "true"
+
+## Pod metadata (empty by default; overridden per test)
+podAnnotations: {}
+podLabels: {}
+annotations: {}
+environments: {}
+
+## Scheduling (empty by default; overridden per test)
+podSecurityContext: {}
+securityContext: {}
+resources: {}
+nodeSelector: {}
+tolerations: []
+affinity: {}
+
+## Resource quota (disabled by default)
+resourceQuota:
+  enabled: false
+
+## Volcano scheduler (disabled by default)
+volcano:
+  enabled: false


### PR DESCRIPTION
## Summary

Refactor all CSGHub Runner unit tests so each template has its own `*_test.yaml`, driven by a shared `tests/values.yaml` that explicitly defines every value the templates consume. Tests no longer rely on defaults in `values.yaml`, so changing those defaults cannot break the suite.

Coverage grows from **6 suites / 30 tests** → **10 suites / 145 tests**, all passing.

## What changed

| File | Tests | Covers |
|---|---|---|
| `values.yaml` (new) | — | Shared baseline; every consumed value explicit, standalone mode |
| `configmap_test.yaml` | 31 | domain derivation (useTop, segment count), kaniko args, s3, tracing, application endpoint resolution, template fallbacks |
| `deployment_test.yaml` | 33 | image edition suffix, label/selector/annotation overrides, optional fields (startupProbe, lifecycle, volumes, topology spread, strategy, hostname/subdomain), pullSecrets/pullPolicy priority |
| `gateway_test.yaml` | 32 | gateway.yaml, envoy-proxy (standalone/builtIn, NodePort/TLS, ssh port padding), metrics, httproutes, httproutes-redirect |
| `knativeserving_test.yaml` | 16 | kourier/gateway-api, opencsg registry override, autoscaler, hooks, registries-skipping-tag-resolving composition |
| `rbac_test.yaml` | 11 | document counts (8 vs 6), role rules, cluster vs namespaced |
| `rbac-argo_test.yaml` (new) | 7 | argo executor Role/SA/RoleBinding, addon controller Role/RoleBinding |
| `service_test.yaml` | 6 | metadata, port/protocol/type overrides |
| `secret_test.yaml` (new) | 3 | docker credential JSON, exact base64 |
| `resource-quota_test.yaml` (new) | 3 | enabled / saas edition / disabled |
| `namespace_test.yaml` (new) | 3 | spaces namespace, mergingNamespace single, custom name |

## Design decisions

- **One suite per template** — each `*_test.yaml` maps to one template file for navigability.
- **Shared `tests/values.yaml`** — explicitly defines every value the templates read, so editing `values.yaml` defaults cannot break tests (verified by changing 7 defaults and re-running: 145/145 still pass).
- **`documentSelector` over `documentIndex`** — multi-document templates select the target document by name at the `it:` level. Per-assert `documentSelector` is silently ignored by helm-unittest 0.8.2, so it is never used inside a single assert.
- **Branch coverage** — every testable `if`/`range`/`with` branch is exercised with a dedicated scenario; untestable branches (configmap `isBuiltIn=true` calls `common.s3.config` → `common.endpoint.minio` only defined in the csghub umbrella; secret/namespace existing-resource lookup paths) are documented with `NOTE` comments.

## Verification

```
helm unittest charts/runner
→ Charts: 1 passed, 1 total
  Test Suites: 10 passed, 10 total
  Tests: 145 passed, 145 total
```

`helm lint charts/runner` passes; pre-push `ct-lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)