### PR TITLE
test(csghub): restore coverage for trustregistry, llmlog ce, minio console, portal s3

### DIFF
--- a/charts/csghub/tests/configmap_test.yaml
+++ b/charts/csghub/tests/configmap_test.yaml
@@ -400,6 +400,19 @@ tests:
       - notExists:
           path: data.STARHUB_SERVER_FEDERATION_ADAPTER_PORT
 
+  - it: omits federation registry host when trustregistry is disabled in saas mode
+    template: csghub/configmap.yaml
+    set:
+      global:
+        edition: "saas"
+      trustregistry:
+        enabled: false
+    asserts:
+      - notExists:
+          path: data.STARHUB_SERVER_FEDERATION_REGISTRY_HOST
+      - notExists:
+          path: data.STARHUB_SERVER_FEDERATION_REGISTRY_PORT
+
   - it: uses derived subdomains when useTop is true
     template: csghub/configmap.yaml
     set:
@@ -473,6 +486,39 @@ tests:
           path: data.CSGHUB_PORTAL_S3_ENDPOINT
           value: "s3.io"
       - equal:
+          path: data.CSGHUB_PORTAL_S3_ACCESS_KEY_ID
+          value: "s3"
+      - equal:
+          path: data.CSGHUB_PORTAL_S3_ACCESS_KEY_SECRET
+          value: "s32025"
+      - equal:
+          path: data.CSGHUB_PORTAL_S3_BUCKET
+          value: "csghub-portal-public"
+      - equal:
+          path: data.CSGHUB_PORTAL_S3_REGION
+          value: "cn-east-1"
+      - equal:
+          path: data.CSGHUB_PORTAL_S3_ENABLE_SSL
+          value: "true"
+      - equal:
+          path: data.CSGHUB_PORTAL_PRIVATE_S3_ENDPOINT
+          value: "s3.io"
+      - equal:
+          path: data.CSGHUB_PORTAL_PRIVATE_S3_ACCESS_KEY_ID
+          value: "s3"
+      - equal:
+          path: data.CSGHUB_PORTAL_PRIVATE_S3_ACCESS_KEY_SECRET
+          value: "s32025"
+      - equal:
+          path: data.CSGHUB_PORTAL_PRIVATE_S3_BUCKET
+          value: "csghub-portal"
+      - equal:
+          path: data.CSGHUB_PORTAL_PRIVATE_S3_REGION
+          value: "cn-east-1"
+      - equal:
+          path: data.CSGHUB_PORTAL_PRIVATE_S3_ENABLE_SSL
+          value: "true"
+      - equal:
           path: data.STARHUB_SERVER_S3_ACCESS_KEY_ID
           value: "s3"
       - equal:
@@ -525,6 +571,18 @@ tests:
           llm:
             log:
               enabled: false
+    asserts:
+      - equal:
+          path: data.OPENCSG_AIGATEWAY_LLMLOG_ENABLE
+          value: "false"
+      - notExists:
+          path: data.OPENCSG_LLMLOG_BUCKET
+
+  - it: omits llmlog config when the global edition is ce
+    template: csghub/configmap.yaml
+    set:
+      global:
+        edition: "ce"
     asserts:
       - equal:
           path: data.OPENCSG_AIGATEWAY_LLMLOG_ENABLE

--- a/charts/csghub/tests/minio-httproutes_test.yaml
+++ b/charts/csghub/tests/minio-httproutes_test.yaml
@@ -73,3 +73,41 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  - it: adds console redirect and rewrite rules when the minio console is enabled
+    template: minio/httproutes.yaml
+    set:
+      minio:
+        console:
+          enabled: true
+    asserts:
+      - lengthEqual:
+          path: spec.rules
+          count: 3
+      - equal:
+          path: spec.rules[1].matches[0].path.type
+          value: "Exact"
+      - equal:
+          path: spec.rules[1].matches[0].path.value
+          value: "/console"
+      - equal:
+          path: spec.rules[1].filters[0].type
+          value: "RequestRedirect"
+      - equal:
+          path: spec.rules[1].filters[0].requestRedirect.path.replaceFullPath
+          value: "/console/"
+      - equal:
+          path: spec.rules[1].filters[0].requestRedirect.statusCode
+          value: 301
+      - equal:
+          path: spec.rules[2].matches[0].path.value
+          value: "/console/"
+      - equal:
+          path: spec.rules[2].filters[0].type
+          value: "URLRewrite"
+      - equal:
+          path: spec.rules[2].backendRefs[0].name
+          value: "csghub-minio"
+      - equal:
+          path: spec.rules[2].backendRefs[0].port
+          value: 9001

--- a/charts/csghub/tests/minio-statefulset_test.yaml
+++ b/charts/csghub/tests/minio-statefulset_test.yaml
@@ -82,6 +82,23 @@ tests:
           path: spec.template.spec.containers[0].image
           value: "opencsg-registry.cn-beijing.cr.aliyuncs.com/opencsghq/minio/minio:RELEASE.2025-09-07T16-13-09Z"
 
+  - it: exposes the minio console address and port when the console is enabled
+    template: minio/statefulset.yaml
+    set:
+      minio:
+        console:
+          enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: "--console-address"
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].name
+          value: "minio-console"
+      - equal:
+          path: spec.template.spec.containers[0].ports[1].containerPort
+          value: 9001
+
   - it: renders nothing when the built-in object storage is disabled
     template: minio/statefulset.yaml
     set:


### PR DESCRIPTION
## Summary
Follow-up to #704. Restore test coverage lost during the csghub unittest refactor:

- Add `omits federation registry host when trustregistry is disabled in saas mode` to `configmap_test.yaml`
- Add `omits llmlog config when the global edition is ce` to `configmap_test.yaml`
- Add `adds console redirect and rewrite rules when the minio console is enabled` to `minio-httproutes_test.yaml`
- Add `exposes the minio console address and port when the console is enabled` to `minio-statefulset_test.yaml`
- Restore the 10 missing `CSGHUB_PORTAL_S3_*` / `CSGHUB_PORTAL_PRIVATE_S3_*` field assertions in the external-infra test

## Test plan
- [x] `helm unittest . --with-subchart=false` — 98 suites / 407 tests pass
- [x] `helm lint .` — 0 failures