### PR TITLE
Fix values required

### DIFF
--- a/charts/agentichub/templates/agenticflow/configmap.yaml
+++ b/charts/agentichub/templates/agenticflow/configmap.yaml
@@ -22,6 +22,8 @@ data:
   {{- $csghubEndpoint := .Values.externalUrl }}
   {{- if $isBuiltIn }}
     {{- $csghubEndpoint = include "common.endpoint.csghub" . }}
+  {{- else }}
+    {{- $csghubEndpoint = required "externalUrl is required when global.chartContext.isBuiltIn=false" .Values.externalUrl }}
   {{- end }}
 
   {{- $redirectState := printf "%s/api/v1/opencsg/callback/csghub" (include "common.endpoint.agenticflow" .) }}
@@ -46,6 +48,8 @@ data:
     {{- $csghubSvc := include "common.names.custom" (list . "core") }}
     {{- $csghubData := (lookup "v1" "ConfigMap" .Release.Namespace $csghubSvc).data | default dict }}
     {{- $apiToken = dig "CSGHUB_PORTAL_STARHUB_API_KEY" (include "csghub.api.token" .) $csghubData }}
+  {{- else }}
+    {{- $apiToken = required "hubAPIToken is required when global.chartContext.isBuiltIn=false" .Values.hubAPIToken }}
   {{- end }}
   CSGHUB_API_ACCESS_TOKEN: {{ $apiToken | quote }}
 

--- a/charts/agentichub/templates/csgbot/configmap.yaml
+++ b/charts/agentichub/templates/csgbot/configmap.yaml
@@ -28,6 +28,8 @@ data:
       {{- $csghubSvc := include "common.names.custom" (list . "core") }}
       {{- $csghubData := (lookup "v1" "ConfigMap" .Release.Namespace $csghubSvc).data | default dict }}
       {{- $apiToken = dig "CSGHUB_PORTAL_STARHUB_API_KEY" (include "csghub.api.token" .) $csghubData }}
+    {{- else }}
+      {{- $apiToken = required "hubAPIToken is required when global.chartContext.isBuiltIn=false" .Values.hubAPIToken }}
     {{- end }}
     hub-access-token = {{ $apiToken | quote }}
     {{- $agenticSvc := include "common.service" (dict "ctx" . "service" "agenticflow") | fromYaml }}
@@ -40,6 +42,8 @@ data:
     {{- $csghubEndpoint := .Values.externalUrl }}
     {{- if $isBuiltIn }}
       {{- $csghubEndpoint = include "common.endpoint.csghub" . }}
+    {{- else }}
+      {{- $csghubEndpoint = required "externalUrl is required when global.chartContext.isBuiltIn=false" .Values.externalUrl }}
     {{- end }}
     endpoint = {{ $csghubEndpoint | quote }}
     portal-endpoint = {{ $csghubEndpoint | quote }}

--- a/charts/agentichub/tests/agenticflow-configmap_test.yaml
+++ b/charts/agentichub/tests/agenticflow-configmap_test.yaml
@@ -224,3 +224,22 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  ## ------------------------------------------------------------------
+  ## Required-value validation
+  ## ------------------------------------------------------------------
+  - it: fails to render when hubAPIToken is empty in standalone mode
+    template: agenticflow/configmap.yaml
+    set:
+      hubAPIToken: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "hubAPIToken is required"
+
+  - it: fails to render when externalUrl is empty in standalone mode
+    template: agenticflow/configmap.yaml
+    set:
+      externalUrl: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "externalUrl is required"

--- a/charts/agentichub/tests/csgbot-configmap_test.yaml
+++ b/charts/agentichub/tests/csgbot-configmap_test.yaml
@@ -392,3 +392,22 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  ## ------------------------------------------------------------------
+  ## Required-value validation
+  ## ------------------------------------------------------------------
+  - it: fails to render when hubAPIToken is empty in standalone mode
+    template: csgbot/configmap.yaml
+    set:
+      hubAPIToken: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "hubAPIToken is required"
+
+  - it: fails to render when externalUrl is empty in standalone mode
+    template: csgbot/configmap.yaml
+    set:
+      externalUrl: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "externalUrl is required"

--- a/charts/agentichub/values.schema.json
+++ b/charts/agentichub/values.schema.json
@@ -120,12 +120,17 @@
       }
     },
     "externalUrl": {
-      "oneOf": [
-        { "type": "null" },
-        { "type": "string", "pattern": "^https?://[a-zA-Z0-9._/:\\-]+$", "description": "External CSGHub URL. Optional when global.chartContext.isBuiltIn=true." }
-      ]
+      "type": ["string", "null"],
+      "description": "External CSGHub URL. Required when global.chartContext.isBuiltIn=false (template enforces via fail).",
+      "if": { "type": "string", "minLength": 1 },
+      "then": { "pattern": "^https?://[a-zA-Z0-9._/:\\-]+$" }
     },
-    "hubAPIToken": { "type": "string", "description": "API token for CSGHub API" },
+    "hubAPIToken": {
+      "type": ["string", "null"],
+      "description": "API token for CSGHub API. Required when global.chartContext.isBuiltIn=false (template enforces via fail).",
+      "if": { "type": "string", "minLength": 1 },
+      "then": { "pattern": "^[A-Za-z0-9._\\-+/=]+$" }
+    },
     "aigateway": {
       "oneOf": [
         { "type": "null" },

--- a/charts/dataflow/templates/dataflow/configmap.yaml
+++ b/charts/dataflow/templates/dataflow/configmap.yaml
@@ -20,7 +20,8 @@ data:
   CSGHUB_ENDPOINT: {{ include "common.endpoint.csghub" . | quote }}
   STUDIO_JUMP_URL: {{ printf "%s/-/label-studio" (include "common.endpoint.csghub" .) | quote }}
   {{- else }}
-  CSGHUB_ENDPOINT: {{ .Values.externalUrl | quote }}
+  {{- $externalUrl := required "externalUrl is required when global.chartContext.isBuiltIn=false" .Values.externalUrl }}
+  CSGHUB_ENDPOINT: {{ $externalUrl | quote }}
   STUDIO_JUMP_URL: {{ include "common.endpoint.labelstudio" . | quote }}
   {{- end }}
   DATA_DIR: "/data/dataflow"

--- a/charts/dataflow/templates/label-studio/configmap.yaml
+++ b/charts/dataflow/templates/label-studio/configmap.yaml
@@ -21,7 +21,8 @@ data:
   CSGHUB_ENDPOINT: {{ include "common.endpoint.csghub" . | quote }}
   LABEL_STUDIO_HOST: {{ printf "%s/-/label-studio" (include "common.endpoint.csghub" .) | quote }}
   {{- else }}
-  CSGHUB_ENDPOINT: {{ .Values.externalUrl | quote }}
+  {{- $externalUrl := required "externalUrl is required when global.chartContext.isBuiltIn=false" .Values.externalUrl }}
+  CSGHUB_ENDPOINT: {{ $externalUrl | quote }}
   LABEL_STUDIO_HOST: {{ include "common.endpoint.labelstudio" . | quote }}
   {{- end }}
   LABEL_STUDIO_PORT: {{ $service | dig "service" "port" 8002 | quote }}

--- a/charts/dataflow/templates/label-studio/httproutes.yaml
+++ b/charts/dataflow/templates/label-studio/httproutes.yaml
@@ -41,7 +41,7 @@ spec:
               {{- if .Values.global.chartContext.isBuiltIn }}
               - {{ include "common.endpoint.csghub" . | quote }}
               {{- else }}
-              - {{ .Values.externalUrl | quote }}
+              - {{ required "externalUrl is required when global.chartContext.isBuiltIn=false" .Values.externalUrl | quote }}
               {{- end }}
             allowCredentials: true
       backendRefs:

--- a/charts/dataflow/tests/dataflow-configmap_test.yaml
+++ b/charts/dataflow/tests/dataflow-configmap_test.yaml
@@ -220,3 +220,14 @@ tests:
       - equal:
           path: data.STUDIO_JUMP_URL
           value: "http://csghub.example.com/-/label-studio"
+
+  ## ------------------------------------------------------------------
+  ## Required-value validation
+  ## ------------------------------------------------------------------
+  - it: fails to render when externalUrl is empty in standalone mode
+    template: dataflow/configmap.yaml
+    set:
+      externalUrl: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "externalUrl is required"

--- a/charts/dataflow/tests/label-studio-configmap_test.yaml
+++ b/charts/dataflow/tests/label-studio-configmap_test.yaml
@@ -180,3 +180,14 @@ tests:
       - equal:
           path: data.LABEL_STUDIO_HOST
           value: "http://csghub.example.com/-/label-studio"
+
+  ## ------------------------------------------------------------------
+  ## Required-value validation
+  ## ------------------------------------------------------------------
+  - it: fails to render when externalUrl is empty in standalone mode
+    template: label-studio/configmap.yaml
+    set:
+      externalUrl: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "externalUrl is required"

--- a/charts/dataflow/tests/label-studio-httproutes_test.yaml
+++ b/charts/dataflow/tests/label-studio-httproutes_test.yaml
@@ -107,3 +107,14 @@ tests:
     asserts:
       - hasDocuments:
           count: 0
+
+  ## ------------------------------------------------------------------
+  ## Required-value validation
+  ## ------------------------------------------------------------------
+  - it: fails to render when externalUrl is empty in standalone mode
+    template: label-studio/httproutes.yaml
+    set:
+      externalUrl: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "externalUrl is required"

--- a/charts/dataflow/values.schema.json
+++ b/charts/dataflow/values.schema.json
@@ -100,10 +100,10 @@
       }
     },
     "externalUrl": {
-      "oneOf": [
-        { "type": "null" },
-        { "type": "string", "pattern": "^https?://[a-zA-Z0-9._/:\\-]+$", "description": "External CSGHub URL for accessing the hub interface. Optional when global.chartContext.isBuiltIn=true." }
-      ]
+      "type": ["string", "null"],
+      "description": "External CSGHub URL for accessing the hub interface. Required when global.chartContext.isBuiltIn=false (template enforces via fail).",
+      "if": { "type": "string", "minLength": 1 },
+      "then": { "pattern": "^https?://[a-zA-Z0-9._/:\\-]+$" }
     },
     "gateway": {
       "type": "object",

--- a/charts/runner/templates/configmap.yaml
+++ b/charts/runner/templates/configmap.yaml
@@ -6,6 +6,12 @@ SPDX-License-Identifier: APACHE-2.0
 {{- $service := include "common.service" . | fromYaml }}
 {{- $serviceName := include "common.names.custom" (list . $service.name) }}
 {{- $isBuiltIn := .Values.global.chartContext.isBuiltIn }}
+{{- $externalUrl := $service.externalUrl }}
+{{- if $isBuiltIn }}
+{{- $externalUrl = include "common.endpoint.csghub" . }}
+{{- else }}
+{{- $externalUrl = required "externalUrl is required when global.chartContext.isBuiltIn=false" $service.externalUrl }}
+{{- end }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -21,7 +27,8 @@ data:
   {{- $apiToken := dig "STARHUB_SERVER_API_TOKEN" (include "csghub.api.token" .) $data }}
   STARHUB_SERVER_API_TOKEN: {{ $apiToken | quote }}
   {{- else }}
-  STARHUB_SERVER_API_TOKEN: {{ $service.hubAPIToken | quote }}
+  {{- $apiToken := required "runner.hubAPIToken is required when global.chartContext.isBuiltIn=false" $service.hubAPIToken }}
+  STARHUB_SERVER_API_TOKEN: {{ $apiToken | quote }}
   {{- end }}
 
   {{- if $isBuiltIn }}
@@ -30,7 +37,7 @@ data:
   {{- $serverSvcPort := dig "service" "port" 8080 $serverSvc }}
   STARHUB_SERVER_RUNNER_WEBHOOK_ENDPOINT: {{ printf "http://%s:%v" $serverSvcName $serverSvcPort | quote }}
   {{- else }}
-  STARHUB_SERVER_RUNNER_WEBHOOK_ENDPOINT: {{ $service.externalUrl | quote }}
+  STARHUB_SERVER_RUNNER_WEBHOOK_ENDPOINT: {{ $externalUrl | quote }}
   {{- end }}
 
   {{- $publicDomain := include "common.endpoint.runner" . }}
@@ -70,7 +77,7 @@ data:
     {{- if $isBuiltIn }}
       {{- $regRegistry = (include "common.registry.config" (dict "ctx" . "service" $service) | fromYaml).registry }}
     {{- else }}
-      {{- $regRegistry = $service.externalUrl | default "" | trimPrefix "https://" | trimPrefix "http://" }}
+      {{- $regRegistry = $externalUrl | default "" | trimPrefix "https://" | trimPrefix "http://" }}
     {{- end }}
   {{- end }}
   {{- if not $regRepository }}
@@ -107,11 +114,7 @@ data:
   STARHUB_SERVER_READINESS_DELAY_SECONDS: {{ $service.space.readinessDelaySeconds | default 120 | quote }}
   STARHUB_SERVER_READINESS_PERIOD_SECONDS: {{ $service.space.readinessPeriodSeconds | default 10 | quote }}
   STARHUB_SERVER_READINESS_FAILURE_THRESHOLD: {{ $service.space.readinessFailureThreshold | default 3 | quote }}
-  {{- if $isBuiltIn }}
-  STARHUB_SERVER_MODEL_DOWNLOAD_ENDPOINT: {{ include "common.endpoint.csghub" . | quote }}
-  {{- else }}
-  STARHUB_SERVER_MODEL_DOWNLOAD_ENDPOINT: {{ $service.externalUrl | quote }}
-  {{- end }}
+  STARHUB_SERVER_MODEL_DOWNLOAD_ENDPOINT: {{ $externalUrl | quote }}
   {{- $registry := or $service.model.dockerRegBase .Values.global.image.registry "docker.io" }}
   STARHUB_SERVER_MODEL_DOCKER_REG_BASE: {{ $registry | quote }}
   STARHUB_SERVER_MODEL_DEPLOY_STATUS_CHECK_INTERVAL: {{ $service.model.deployStatusCheckInterval | default 10 | quote }}

--- a/charts/runner/tests/configmap_test.yaml
+++ b/charts/runner/tests/configmap_test.yaml
@@ -172,6 +172,15 @@ tests:
           path: data.STARHUB_SERVER_RUNNER_IMAGE_BUILDER_STATUS_TTL
           value: "999"
 
+  ## Required-value validation
+  ## ------------------------------------------------------------------
+  - it: fails to render when hubAPIToken is empty in standalone mode
+    set:
+      hubAPIToken: ""
+    asserts:
+      - failedTemplate:
+          errorPattern: "hubAPIToken is required"
+
   - it: derives the docker registry base from externalUrl when registry is empty
     set:
       registry:

--- a/charts/runner/values.schema.json
+++ b/charts/runner/values.schema.json
@@ -126,8 +126,18 @@
         }
       }
     },
-    "hubAPIToken": { "type": "string", "description": "API token for authenticating with CSGHub API" },
-    "originClusterID": { "type": "string", "description": "Unique identifier for the origin cluster" },
+    "hubAPIToken": {
+      "type": ["string", "null"],
+      "description": "API token for authenticating with CSGHub API. Required when global.chartContext.isBuiltIn=false (template enforces via fail).",
+      "if": { "type": "string", "minLength": 1 },
+      "then": { "pattern": "^[A-Za-z0-9._\\-+/=]+$" }
+    },
+    "originClusterID": {
+      "type": ["string", "null"],
+      "description": "Unique identifier for the origin cluster.",
+      "if": { "type": "string", "minLength": 1 },
+      "then": { "pattern": "^[A-Za-z0-9._\\-]+$" }
+    },
     "logging": {
       "type": "object",
       "properties": {

--- a/lefthook.yaml
+++ b/lefthook.yaml
@@ -37,10 +37,18 @@ pre-commit:
             chart_name=$(basename "${chart_dir}")
             echo "Testing template rendering for ${chart_name}"
 
+            # Use tests/values.yaml as the rendering input when available, so that
+            # standalone-only fields (e.g. agentichub.hubAPIToken, dataflow.externalUrl,
+            # runner.originClusterID) are populated for the render check.
+            values_args=()
+            if [ -f "${chart_dir}tests/values.yaml" ]; then
+              values_args=(-f "${chart_dir}tests/values.yaml")
+            fi
+
             echo "🔧 Testing template rendering for ${chart_name}"
-            if ! helm template "test-${chart_name}" "${chart_dir}" --dry-run=client > /dev/null 2>&1; then
+            if ! helm template "test-${chart_name}" "${chart_dir}" --dry-run=client "${values_args[@]}" > /dev/null 2>&1; then
               echo "❌ Template rendering failed for ${chart_name}"
-              helm template "test-${chart_name}" "${chart_dir}" --dry-run=client
+              helm template "test-${chart_name}" "${chart_dir}" --dry-run=client "${values_args[@]}"
               exit 1
             fi
 


### PR DESCRIPTION
## Summary

Add template-level `required` validation for standalone (isBuiltIn=false) deployment of the runner, dataflow and agentichub charts, so that missing required values fail fast at render time instead of at runtime.

### Required-value validation

- **runner**: `externalUrl` and `hubAPIToken` are now required in standalone mode. `externalUrl` is extracted once at the top of the ConfigMap and reused (webhook endpoint, model download endpoint, registry derivation), keeping the built-in branch intact.
- **dataflow**: `externalUrl` is required in standalone mode in the dataflow ConfigMap, label-studio ConfigMap and label-studio HTTPRoutes.
- **agentichub**: `externalUrl` and `hubAPIToken` are required in standalone mode in the agenticflow and csgbot ConfigMaps.

`originClusterID` remains optional in both built-in and standalone modes.

### Schema updates

- `runner`: `hubAPIToken`/`originClusterID` accept `null` and validate format via `if`/`then` when non-empty (the template, not the schema, enforces requiredness, so built-in deployments stay flexible).
- `dataflow`/`agentichub`: `externalUrl` accepts `null` and validates the URL pattern when set.

### Test and tooling

- lefthook `helm-template` hook now passes `tests/values.yaml` when present, so standalone charts render under the hook.
- Added helm-unittest cases covering the new fail-fast validation for runner, dataflow and agentichub.

## Test plan

- [x] `helm template` standalone renders pass with explicit `tests/values.yaml`
- [x] helm-unittest suites green for runner / dataflow / agentichub
- [x] Missing `externalUrl`/`hubAPIToken` triggers the expected `required` error